### PR TITLE
Drop constraint on FloatElem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 [[package]]
 name = "burn"
 version = "0.10.0"
-source = "git+https://github.com/burn-rs/burn.git?rev=dbc5f0a340136251170138f8825062b42ed2d096#dbc5f0a340136251170138f8825062b42ed2d096"
+source = "git+https://github.com/burn-rs/burn.git?rev=251ec00070eb67b65e6efb6f3fe449ed3f00a741#251ec00070eb67b65e6efb6f3fe449ed3f00a741"
 dependencies = [
  "burn-core",
  "burn-train",
@@ -132,7 +132,7 @@ dependencies = [
 [[package]]
 name = "burn-autodiff"
 version = "0.10.0"
-source = "git+https://github.com/burn-rs/burn.git?rev=dbc5f0a340136251170138f8825062b42ed2d096#dbc5f0a340136251170138f8825062b42ed2d096"
+source = "git+https://github.com/burn-rs/burn.git?rev=251ec00070eb67b65e6efb6f3fe449ed3f00a741#251ec00070eb67b65e6efb6f3fe449ed3f00a741"
 dependencies = [
  "burn-common",
  "burn-tensor",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "burn-common"
 version = "0.10.0"
-source = "git+https://github.com/burn-rs/burn.git?rev=dbc5f0a340136251170138f8825062b42ed2d096#dbc5f0a340136251170138f8825062b42ed2d096"
+source = "git+https://github.com/burn-rs/burn.git?rev=251ec00070eb67b65e6efb6f3fe449ed3f00a741#251ec00070eb67b65e6efb6f3fe449ed3f00a741"
 dependencies = [
  "const-random",
  "rand",
@@ -155,7 +155,7 @@ dependencies = [
 [[package]]
 name = "burn-core"
 version = "0.10.0"
-source = "git+https://github.com/burn-rs/burn.git?rev=dbc5f0a340136251170138f8825062b42ed2d096#dbc5f0a340136251170138f8825062b42ed2d096"
+source = "git+https://github.com/burn-rs/burn.git?rev=251ec00070eb67b65e6efb6f3fe449ed3f00a741#251ec00070eb67b65e6efb6f3fe449ed3f00a741"
 dependencies = [
  "bincode",
  "burn-autodiff",
@@ -180,7 +180,7 @@ dependencies = [
 [[package]]
 name = "burn-dataset"
 version = "0.10.0"
-source = "git+https://github.com/burn-rs/burn.git?rev=dbc5f0a340136251170138f8825062b42ed2d096#dbc5f0a340136251170138f8825062b42ed2d096"
+source = "git+https://github.com/burn-rs/burn.git?rev=251ec00070eb67b65e6efb6f3fe449ed3f00a741#251ec00070eb67b65e6efb6f3fe449ed3f00a741"
 dependencies = [
  "csv",
  "derive-new",
@@ -205,7 +205,7 @@ dependencies = [
 [[package]]
 name = "burn-derive"
 version = "0.10.0"
-source = "git+https://github.com/burn-rs/burn.git?rev=dbc5f0a340136251170138f8825062b42ed2d096#dbc5f0a340136251170138f8825062b42ed2d096"
+source = "git+https://github.com/burn-rs/burn.git?rev=251ec00070eb67b65e6efb6f3fe449ed3f00a741#251ec00070eb67b65e6efb6f3fe449ed3f00a741"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -216,7 +216,7 @@ dependencies = [
 [[package]]
 name = "burn-ndarray"
 version = "0.10.0"
-source = "git+https://github.com/burn-rs/burn.git?rev=dbc5f0a340136251170138f8825062b42ed2d096#dbc5f0a340136251170138f8825062b42ed2d096"
+source = "git+https://github.com/burn-rs/burn.git?rev=251ec00070eb67b65e6efb6f3fe449ed3f00a741#251ec00070eb67b65e6efb6f3fe449ed3f00a741"
 dependencies = [
  "burn-autodiff",
  "burn-common",
@@ -234,7 +234,7 @@ dependencies = [
 [[package]]
 name = "burn-tensor"
 version = "0.10.0"
-source = "git+https://github.com/burn-rs/burn.git?rev=dbc5f0a340136251170138f8825062b42ed2d096#dbc5f0a340136251170138f8825062b42ed2d096"
+source = "git+https://github.com/burn-rs/burn.git?rev=251ec00070eb67b65e6efb6f3fe449ed3f00a741#251ec00070eb67b65e6efb6f3fe449ed3f00a741"
 dependencies = [
  "burn-tensor-testgen",
  "derive-new",
@@ -250,7 +250,7 @@ dependencies = [
 [[package]]
 name = "burn-tensor-testgen"
 version = "0.10.0"
-source = "git+https://github.com/burn-rs/burn.git?rev=dbc5f0a340136251170138f8825062b42ed2d096#dbc5f0a340136251170138f8825062b42ed2d096"
+source = "git+https://github.com/burn-rs/burn.git?rev=251ec00070eb67b65e6efb6f3fe449ed3f00a741#251ec00070eb67b65e6efb6f3fe449ed3f00a741"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -260,7 +260,7 @@ dependencies = [
 [[package]]
 name = "burn-train"
 version = "0.10.0"
-source = "git+https://github.com/burn-rs/burn.git?rev=dbc5f0a340136251170138f8825062b42ed2d096#dbc5f0a340136251170138f8825062b42ed2d096"
+source = "git+https://github.com/burn-rs/burn.git?rev=251ec00070eb67b65e6efb6f3fe449ed3f00a741#251ec00070eb67b65e6efb6f3fe449ed3f00a741"
 dependencies = [
  "burn-core",
  "derive-new",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "BSD-3-Clause"
 [dependencies.burn]
 # version = "0.10.0"
 git = "https://github.com/burn-rs/burn.git"
-rev = "dbc5f0a340136251170138f8825062b42ed2d096"
+rev = "251ec00070eb67b65e6efb6f3fe449ed3f00a741"
 # path = "../burn/burn"
 default-features = false
 features = ["std", "train-minimal", "autodiff", "dataset-minimal", "ndarray"]
@@ -17,7 +17,7 @@ features = ["std", "train-minimal", "autodiff", "dataset-minimal", "ndarray"]
 [dev-dependencies.burn]
 # version = "0.10.0"
 git = "https://github.com/burn-rs/burn.git"
-rev = "dbc5f0a340136251170138f8825062b42ed2d096"
+rev = "251ec00070eb67b65e6efb6f3fe449ed3f00a741"
 # path = "../burn/burn"
 features = ["train", "dataset-sqlite-bundled"]
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -15,7 +15,7 @@ pub struct Model<B: Backend> {
     pub config: ModelConfig,
 }
 
-impl<B: Backend<FloatElem = f32>> Model<B> {
+impl<B: Backend> Model<B> {
     #[allow(clippy::new_without_default)]
     pub fn new(config: ModelConfig) -> Self {
         let initial_stability = config.initial_stability.unwrap_or([0.4, 0.6, 2.4, 5.8]);
@@ -173,14 +173,14 @@ pub struct ModelConfig {
 }
 
 impl ModelConfig {
-    pub fn init<B: Backend<FloatElem = f32>>(&self) -> Model<B> {
+    pub fn init<B: Backend>(&self) -> Model<B> {
         Model::new(self.clone())
     }
 }
 
 /// This is the main structure provided by this crate. It can be used
 /// for both weight training, and for reviews.
-pub struct FSRS<B: Backend<FloatElem = f32> = NdArrayBackend> {
+pub struct FSRS<B: Backend = NdArrayBackend> {
     model: Option<Model<B>>,
     device: B::Device,
 }
@@ -193,8 +193,8 @@ impl FSRS<NdArrayBackend> {
     }
 }
 
-impl<B: Backend<FloatElem = f32>> FSRS<B> {
-    pub fn new_with_backend<B2: Backend<FloatElem = f32>>(
+impl<B: Backend> FSRS<B> {
+    pub fn new_with_backend<B2: Backend>(
         mut weights: Option<&Weights>,
         device: B2::Device,
     ) -> Result<FSRS<B2>> {
@@ -222,7 +222,7 @@ impl<B: Backend<FloatElem = f32>> FSRS<B> {
     }
 }
 
-pub(crate) fn weights_to_model<B: Backend<FloatElem = f32>>(weights: &Weights) -> Model<B> {
+pub(crate) fn weights_to_model<B: Backend>(weights: &Weights) -> Model<B> {
     let config = ModelConfig::default();
     let mut model = Model::<B>::new(config);
     model.w = Param::from(Tensor::from_floats(Data::new(

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -335,7 +335,7 @@ fn simulate(config: &SimulatorConfig, w: &[f64], request_retention: f64, seed: O
     memorized_cnt_per_day[memorized_cnt_per_day.len() - 1]
 }
 
-impl<B: Backend<FloatElem = f32>> FSRS<B> {
+impl<B: Backend> FSRS<B> {
     /// For the given simulator parameters and weights, determine the suggested `desired_retention`
     /// value.
     pub fn optimal_retention<F>(

--- a/src/training.rs
+++ b/src/training.rs
@@ -39,7 +39,7 @@ impl<B: Backend> BCELoss<B> {
     }
 }
 
-impl<B: Backend<FloatElem = f32>> Model<B> {
+impl<B: Backend> Model<B> {
     pub fn forward_classification(
         &self,
         t_historys: Tensor<B, 2>,
@@ -63,7 +63,7 @@ impl<B: Backend<FloatElem = f32>> Model<B> {
     }
 }
 
-impl<B: ADBackend<FloatElem = f32>> Model<B> {
+impl<B: ADBackend> Model<B> {
     fn freeze_initial_stability(&self, mut grad: B::Gradients) -> B::Gradients {
         let grad_tensor = self.w.grad(&grad).unwrap();
         let updated_grad_tensor = grad_tensor.slice_assign([0..4], Tensor::zeros([4]));
@@ -74,7 +74,7 @@ impl<B: ADBackend<FloatElem = f32>> Model<B> {
     }
 }
 
-impl<B: ADBackend<FloatElem = f32>> TrainStep<FSRSBatch<B>, ClassificationOutput<B>> for Model<B> {
+impl<B: ADBackend> TrainStep<FSRSBatch<B>, ClassificationOutput<B>> for Model<B> {
     fn step(&self, batch: FSRSBatch<B>) -> TrainOutput<ClassificationOutput<B>> {
         let item = self.forward_classification(
             batch.t_historys,
@@ -104,7 +104,7 @@ impl<B: ADBackend<FloatElem = f32>> TrainStep<FSRSBatch<B>, ClassificationOutput
     }
 }
 
-impl<B: Backend<FloatElem = f32>> ValidStep<FSRSBatch<B>, ClassificationOutput<B>> for Model<B> {
+impl<B: Backend> ValidStep<FSRSBatch<B>, ClassificationOutput<B>> for Model<B> {
     fn step(&self, batch: FSRSBatch<B>) -> ClassificationOutput<B> {
         self.forward_classification(
             batch.t_historys,
@@ -188,7 +188,7 @@ pub(crate) struct TrainingConfig {
     pub learning_rate: f64,
 }
 
-impl<B: Backend<FloatElem = f32>> FSRS<B> {
+impl<B: Backend> FSRS<B> {
     /// Calculate appropriate weights for the provided review history.
     pub fn compute_weights(
         &self,
@@ -213,11 +213,11 @@ impl<B: Backend<FloatElem = f32>> FSRS<B> {
             None,
         );
 
-        Ok(model?.w.val().to_data().value)
+        Ok(model?.w.val().to_data().convert().value)
     }
 }
 
-fn train<B: ADBackend<FloatElem = f32>>(
+fn train<B: ADBackend>(
     items: Vec<FSRSItem>,
     config: &TrainingConfig,
     device: B::Device,

--- a/src/weight_clipper.rs
+++ b/src/weight_clipper.rs
@@ -1,6 +1,6 @@
 use burn::tensor::{backend::Backend, Data, Tensor};
 
-pub(crate) fn weight_clipper<B: Backend<FloatElem = f32>>(weights: Tensor<B, 1>) -> Tensor<B, 1> {
+pub(crate) fn weight_clipper<B: Backend>(weights: Tensor<B, 1>) -> Tensor<B, 1> {
     const CLAMPS: [(f32, f32); 13] = [
         (1.0, 10.0),
         (0.1, 5.0),
@@ -18,14 +18,14 @@ pub(crate) fn weight_clipper<B: Backend<FloatElem = f32>>(weights: Tensor<B, 1>)
     ];
     // https://regex101.com/r/21mXNI/1
 
-    let val: &mut Vec<f32> = &mut weights.to_data().value;
+    let val: &mut Vec<f32> = &mut weights.to_data().convert().value;
 
     val.iter_mut()
         .skip(4)
         .zip(CLAMPS)
         .for_each(|(w, (low, high))| *w = w.clamp(low, high));
 
-    Tensor::from_data(Data::new(val.clone(), weights.shape()))
+    Tensor::from_data(Data::new(val.clone(), weights.shape()).convert())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
https://github.com/open-spaced-repetition/fsrs-rs/issues/1#issuecomment-1681801153 has been addressed by Burn:
https://github.com/burn-rs/burn/issues/795

With this change, if we wanted to switch to f16/f64 in the future, we'd only need to change the backend creation.