### PR TITLE
add hook reminds

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,17 @@ The Free Spaced Repetition Scheduler ([FSRS](https://github.com/open-spaced-repe
 FSRS-rs is a Rust implementation of FSRS. It is designed to be used in [Anki](https://apps.ankiweb.net/), a popular spaced repetition software. [Anki 23.10](https://github.com/ankitects/anki/releases/tag/23.10) has already integrated FSRS as an alternative scheduler.
 
 For more information about the algorithm, please refer to [the wiki page of FSRS](https://github.com/open-spaced-repetition/fsrs4anki/wiki/The-Algorithm).
+
+---
+
+## Development
+
+add
+
+```sh
+#!/bin/sh
+cargo fmt
+cargo clippy -- -D warnings
+```
+
+to `.git/hooks/pre-commit`, then `chmod +x .git/hooks/pre-commit`


### PR DESCRIPTION
Will reduce some CI format error.

because of <https://stackoverflow.com/questions/427207/can-git-hook-scripts-be-managed-along-with-the-repository/427269#427269>, can't add it into repo directly.

