### PR TITLE
Feat/minimal workload for optimal retention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "fsrs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "burn",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "fsrs"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "burn",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsrs"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Open Spaced Repetition"]
 categories = ["algorithms", "science"]
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsrs"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Open Spaced Repetition"]
 categories = ["algorithms", "science"]
 edition = "2021"

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -437,7 +437,7 @@ where
         / n as f64)
 }
 
-const SAMPLE_SIZE: usize = 16;
+const SAMPLE_SIZE: usize = 4;
 
 /// https://github.com/scipy/scipy/blob/5e4a5e3785f79dd4e8930eed883da89958860db2/scipy/optimize/_optimize.py#L2894
 fn bracket<F>(
@@ -770,7 +770,7 @@ mod tests {
             ..Default::default()
         };
         let optimal_retention = fsrs.optimal_retention(&config, &[], |_v| true).unwrap();
-        assert_eq!(optimal_retention, 0.786971401181512);
+        assert_eq!(optimal_retention, 0.7984864824748231);
         assert!(fsrs.optimal_retention(&config, &[1.], |_v| true).is_err());
         Ok(())
     }


### PR DESCRIPTION
- https://github.com/open-spaced-repetition/optimal-desired-retention/blob/main/notebook.ipynb
- https://github.com/open-spaced-repetition/fsrs-optimizer/pull/89

I refactor the approach to calculate the optimal retention. Now the optimizer will output the optimal retention to minimize the workload/cost per memorization.

<img width="625" alt="image" src="https://github.com/open-spaced-repetition/fsrs-rs/assets/32575846/ae5af52a-e9df-4a64-94ff-bfdac17019f0">

Ideally, the user only needs to input `learn_span` in the new optimizer for retention. So it's easier to use than the previous implementation.

<img width="491" alt="image" src="https://github.com/open-spaced-repetition/fsrs-rs/assets/32575846/4712be6a-a34d-4f77-b9a2-e78f8c4d2315">

By the way, we may notice users that desired retention <  optimal retention is worse than desired retention > optimal retention. Because the former means **less** memorization & **more** workload and the latter means **more** memorization & **more** workload.
