### PR TITLE
Speed up optimal_retention()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "fsrs"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "burn",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsrs"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Open Spaced Repetition"]
 categories = ["algorithms", "science"]
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ add
 #!/bin/sh
 cargo fmt
 cargo clippy -- -D warnings
+git add .
 ```
 
 to `.git/hooks/pre-commit`, then `chmod +x .git/hooks/pre-commit`

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -9,6 +9,7 @@ use criterion::criterion_main;
 use criterion::Criterion;
 use fsrs::FSRSReview;
 use fsrs::NextStates;
+use fsrs::SimulatorConfig;
 use fsrs::FSRS;
 use fsrs::{FSRSItem, MemoryState};
 use itertools::Itertools;
@@ -34,6 +35,10 @@ pub(crate) fn next_states(inf: &FSRS) -> NextStates {
     .unwrap()
 }
 
+pub(crate) fn optimal_retention(inf: &FSRS, config: &SimulatorConfig) -> f64 {
+    inf.optimal_retention(config, &[], |_v| true).unwrap()
+}
+
 pub fn criterion_benchmark(c: &mut Criterion) {
     let fsrs = FSRS::new(Some(&[
         0.81497127,
@@ -55,9 +60,19 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         2.6646678,
     ]))
     .unwrap();
-
+    let config = SimulatorConfig {
+        deck_size: 3650,
+        learn_span: 365,
+        max_cost_perday: f64::INFINITY,
+        learn_limit: 10,
+        loss_aversion: 1.0,
+        ..Default::default()
+    };
     c.bench_function("calc_mem", |b| b.iter(|| black_box(calc_mem(&fsrs, 100))));
     c.bench_function("next_states", |b| b.iter(|| black_box(next_states(&fsrs))));
+    c.bench_function("optimal_retention", |b| {
+        b.iter(|| black_box(optimal_retention(&fsrs, &config)))
+    });
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -683,11 +683,11 @@ mod tests {
             learn_span,
             max_cost_perday: f64::INFINITY,
             learn_limit,
-            loss_aversion: 1.0,
+            loss_aversion: 2.5,
             ..Default::default()
         };
         let optimal_retention = fsrs.optimal_retention(&config, &[], |_v| true).unwrap();
-        assert_eq!(optimal_retention, 0.7984864824748231);
+        assert_eq!(optimal_retention, 0.8263932);
         assert!(fsrs.optimal_retention(&config, &[1.], |_v| true).is_err());
         Ok(())
     }

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -492,7 +492,7 @@ impl<B: Backend> FSRS<B> {
             R_MIN,
             sample(config, parameters, R_MIN, SAMPLE_SIZE, &mut progress)?,
         );
-        let (mut x, mut w, mut v) = (xb, xb, xb);
+        let (mut x, mut v, mut w) = (xb, xb, xb);
         let (mut fx, mut fv, mut fw) = (fb, fb, fb);
         let (mut a, mut b) = (R_MIN, R_MAX);
         let mut deltax: f64 = 0.0;

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -488,7 +488,10 @@ impl<B: Backend> FSRS<B> {
         let maxiter = 64;
         let tol = 0.01f64;
 
-        let (xb, fb) = (R_MIN, sample(config, parameters, R_MIN, SAMPLE_SIZE, &mut progress)?);
+        let (xb, fb) = (
+            R_MIN,
+            sample(config, parameters, R_MIN, SAMPLE_SIZE, &mut progress)?,
+        );
         let (mut x, mut w, mut v) = (xb, xb, xb);
         let (mut fx, mut fv, mut fw) = (fb, fb, fb);
         let (mut a, mut b) = (R_MIN, R_MAX);
@@ -672,12 +675,14 @@ mod tests {
 
     #[test]
     fn optimal_retention() -> Result<()> {
+        let learn_span = 1000;
+        let learn_limit = 10;
         let fsrs = FSRS::new(None)?;
         let config = SimulatorConfig {
-            deck_size: 10000,
-            learn_span: 1000,
+            deck_size: learn_span * learn_limit,
+            learn_span,
             max_cost_perday: f64::INFINITY,
-            learn_limit: 10,
+            learn_limit,
             loss_aversion: 1.0,
             ..Default::default()
         };


### PR DESCRIPTION
It's ~25% faster than before, especially when the `learn_span` is long.

The time complexity of `simulate()` is O(kn^2), where k is `learn_limit` and n is `learn_span`. It costs ~30s to find the optimal retention with `learn_span=3650` and `learn_limit=10`. In previous implementation, it costs ~40s.

```shell
cargo test --release -- optimal_retention::tests::optimal_retention
```

It's not recommended to set a `learn_span` greater than 3650.

It costs ~250s to find the optimal retention with `learn_span=10000`.

I hope it is the last improvement on FSRS-rs before the release of Anki 24.04. @dae 