### PR TITLE
remove `num_workers`

### DIFF
--- a/src/training.rs
+++ b/src/training.rs
@@ -173,8 +173,6 @@ pub(crate) struct TrainingConfig {
     pub num_epochs: usize,
     #[config(default = 512)]
     pub batch_size: usize,
-    #[config(default = 1)]
-    pub num_workers: usize,
     #[config(default = 42)]
     pub seed: u64,
     #[config(default = 4e-2)]


### PR DESCRIPTION
Not sure if this was intentionally left in to reduce breaking changes, but I think this should've been removed with https://github.com/open-spaced-repetition/fsrs-rs/pull/163