### PR TITLE
update to 0.13.1

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,40 @@
+name: Auto merge main into fsrs-browser
+# Run on push to fsrs-browser to make CI pass when there's a merge conflict and manual merging is required.
+on:
+  push:
+    branches:
+      - 'fsrs-browser'
+  release:
+    types: [published]
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Compute tag
+      id: compute-tag
+      run: |
+        set -e
+        TAG=$(cat Cargo.toml \
+          | grep --extended-regexp "^version =" \
+          | grep --extended-regexp --only-matching "[0-9]+\.[0-9]+.[0-9]+[-\.\+a-zA-Z0-9]*" \
+          | head --lines=1)
+        echo "tag=v$TAG" >> "$GITHUB_OUTPUT"
+
+    - name: Set Git config
+      run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "Github Actions"
+
+    - name: Merge main into fsrs-browser
+      env:
+        TAG: ${{ steps.compute-tag.outputs.tag }}
+      run: |
+          git fetch --unshallow
+          git checkout fsrs-browser
+          git pull
+          git merge main -m "Auto-merge for $TAG"
+          git push

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,7 @@
 name: Check code
 on:
   pull_request:
+    branches: [ "main" ]
 
 jobs:
   build-linux:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -174,7 +174,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "burn"
-version = "0.12.1"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c0ed4069416ef160c5cc893aecc657a49722a4a4295fb723c6ff3a05f17161"
 dependencies = [
  "burn-core",
  "burn-train",
@@ -182,17 +184,22 @@ dependencies = [
 
 [[package]]
 name = "burn-autodiff"
-version = "0.12.1"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17557c26c1cdd56bf90a54bb82979158019f3b03a086b40ac62fb75792cc7ea8"
 dependencies = [
  "burn-common",
  "burn-tensor",
  "derive-new",
+ "log",
  "spin",
 ]
 
 [[package]]
 name = "burn-candle"
-version = "0.12.1"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14403c2f73e714577a4547e954d07858a4c13e429746794b9d4273b919f6d4eb"
 dependencies = [
  "burn-tensor",
  "candle-core",
@@ -202,7 +209,9 @@ dependencies = [
 
 [[package]]
 name = "burn-common"
-version = "0.12.1"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6ddcaa76012e2715f143d439d4579362e06e8b2a4a8d236cfb07486f840f75"
 dependencies = [
  "async-trait",
  "derive-new",
@@ -216,7 +225,9 @@ dependencies = [
 
 [[package]]
 name = "burn-compute"
-version = "0.12.1"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fbde921ff279f5f7627ccb66ed47aa2ad0f3ffc0562448a07889dc2c36767c"
 dependencies = [
  "burn-common",
  "derive-new",
@@ -232,7 +243,9 @@ dependencies = [
 
 [[package]]
 name = "burn-core"
-version = "0.12.1"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f98e5b4abcbf7b08bbaa2a78add64b1721db1f299af562393ff554b2a4914d7"
 dependencies = [
  "bincode",
  "burn-autodiff",
@@ -240,7 +253,6 @@ dependencies = [
  "burn-common",
  "burn-dataset",
  "burn-derive",
- "burn-fusion",
  "burn-ndarray",
  "burn-tensor",
  "burn-wgpu",
@@ -248,8 +260,8 @@ dependencies = [
  "flate2",
  "half",
  "hashbrown 0.14.3",
- "libm",
  "log",
+ "num-traits",
  "rand",
  "rmp-serde",
  "serde",
@@ -259,7 +271,9 @@ dependencies = [
 
 [[package]]
 name = "burn-dataset"
-version = "0.12.1"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d015b7cbb755e6ff8061c57b1f073bbf0bcec51a6976f7085adaa94a70f6b2"
 dependencies = [
  "csv",
  "derive-new",
@@ -283,7 +297,9 @@ dependencies = [
 
 [[package]]
 name = "burn-derive"
-version = "0.12.1"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "270f0e0d4e57d46e0e754e10c543a77b9503daa58e2c09f76ab1cc56a9c85e8e"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -293,7 +309,9 @@ dependencies = [
 
 [[package]]
 name = "burn-fusion"
-version = "0.12.1"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb3c6ec86052f9ea82d5e978c6f7e09365359705fa512db5748564a9e4f8c9d"
 dependencies = [
  "burn-common",
  "burn-tensor",
@@ -305,8 +323,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "burn-jit"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f30801b8a84f88bd49861ec9d70f4ad86e56340128a914c04c21d76e43e551e"
+dependencies = [
+ "burn-common",
+ "burn-compute",
+ "burn-fusion",
+ "burn-tensor",
+ "bytemuck",
+ "derive-new",
+ "hashbrown 0.14.3",
+ "log",
+ "num-traits",
+ "rand",
+ "serde",
+ "spin",
+ "text_placeholder",
+]
+
+[[package]]
 name = "burn-ndarray"
-version = "0.12.1"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b88fc2a1244f2dbd9df295b82b106232666848894f1e0b694bd3a60fa8582b7"
 dependencies = [
  "burn-autodiff",
  "burn-common",
@@ -322,14 +363,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "burn-tch"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcbfdd03dcd9ac305e4b006595f35bfdfe030a01e79b2f1a58a9c7ad2db91ca"
+dependencies = [
+ "burn-tensor",
+ "half",
+ "libc",
+ "rand",
+ "tch",
+]
+
+[[package]]
 name = "burn-tensor"
-version = "0.12.1"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac227ff0ff1e2ba2001795fdb76d011e33a952f4c9a9cd112207a23d4c43561"
 dependencies = [
  "burn-common",
  "derive-new",
  "half",
  "hashbrown 0.14.3",
- "libm",
  "num-traits",
  "rand",
  "rand_distr",
@@ -338,7 +393,9 @@ dependencies = [
 
 [[package]]
 name = "burn-train"
-version = "0.12.1"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451a711918eaa8a33fe0682f6fefd6bf77f34a0a9c6437e6d7f87a8b0c3590f4"
 dependencies = [
  "burn-core",
  "derive-new",
@@ -356,22 +413,21 @@ dependencies = [
 
 [[package]]
 name = "burn-wgpu"
-version = "0.12.1"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a65a4ba31a4afb107a9a95e51636cc04f9b2a391f14210fb087f44fd05a1e91"
 dependencies = [
  "burn-common",
  "burn-compute",
+ "burn-fusion",
+ "burn-jit",
  "burn-tensor",
  "bytemuck",
  "derive-new",
  "futures-intrusive",
  "hashbrown 0.14.3",
  "log",
- "num-traits",
  "pollster",
- "rand",
- "serde",
- "spin",
- "text_placeholder",
  "wgpu",
 ]
 
@@ -403,9 +459,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "candle-core"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db8659ea87ee8197d2fc627348916cce0561330ee7ae3874e771691d3cecb2f"
+checksum = "6f1b20174c1707e20f4cb364a355b449803c03e9b0c9193324623cf9787a4e00"
 dependencies = [
  "byteorder",
  "gemm",
@@ -1068,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1081,9 +1137,9 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
+checksum = "3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2"
 dependencies = [
  "color_quant",
  "weezl",
@@ -1234,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1334,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.8"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034bbe799d1909622a74d1193aa50147769440040ff36cb2baa947609b0a4e23"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -1514,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "malloc_buf"
@@ -1897,9 +1953,9 @@ checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
@@ -2031,9 +2087,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.8.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -2237,18 +2293,18 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2257,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
@@ -2462,9 +2518,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -2494,18 +2550,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2650,9 +2706,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "getrandom",
  "rand",
@@ -2793,9 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "web-time"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee269d72cc29bf77a2c4bc689cc750fb39f5cbd493d2205bbb3f5c7779cf7b0"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,9 +174,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "burn"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c0ed4069416ef160c5cc893aecc657a49722a4a4295fb723c6ff3a05f17161"
+version = "0.13.1"
 dependencies = [
  "burn-core",
  "burn-train",
@@ -184,9 +182,7 @@ dependencies = [
 
 [[package]]
 name = "burn-autodiff"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17557c26c1cdd56bf90a54bb82979158019f3b03a086b40ac62fb75792cc7ea8"
+version = "0.13.1"
 dependencies = [
  "burn-common",
  "burn-tensor",
@@ -197,9 +193,7 @@ dependencies = [
 
 [[package]]
 name = "burn-candle"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14403c2f73e714577a4547e954d07858a4c13e429746794b9d4273b919f6d4eb"
+version = "0.13.1"
 dependencies = [
  "burn-tensor",
  "candle-core",
@@ -209,9 +203,7 @@ dependencies = [
 
 [[package]]
 name = "burn-common"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6ddcaa76012e2715f143d439d4579362e06e8b2a4a8d236cfb07486f840f75"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "derive-new",
@@ -225,9 +217,7 @@ dependencies = [
 
 [[package]]
 name = "burn-compute"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fbde921ff279f5f7627ccb66ed47aa2ad0f3ffc0562448a07889dc2c36767c"
+version = "0.13.1"
 dependencies = [
  "burn-common",
  "derive-new",
@@ -243,9 +233,7 @@ dependencies = [
 
 [[package]]
 name = "burn-core"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f98e5b4abcbf7b08bbaa2a78add64b1721db1f299af562393ff554b2a4914d7"
+version = "0.13.1"
 dependencies = [
  "bincode",
  "burn-autodiff",
@@ -271,9 +259,7 @@ dependencies = [
 
 [[package]]
 name = "burn-dataset"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d015b7cbb755e6ff8061c57b1f073bbf0bcec51a6976f7085adaa94a70f6b2"
+version = "0.13.1"
 dependencies = [
  "csv",
  "derive-new",
@@ -297,9 +283,7 @@ dependencies = [
 
 [[package]]
 name = "burn-derive"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "270f0e0d4e57d46e0e754e10c543a77b9503daa58e2c09f76ab1cc56a9c85e8e"
+version = "0.13.1"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -308,29 +292,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "burn-fusion"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb3c6ec86052f9ea82d5e978c6f7e09365359705fa512db5748564a9e4f8c9d"
-dependencies = [
- "burn-common",
- "burn-tensor",
- "derive-new",
- "hashbrown 0.14.3",
- "log",
- "serde",
- "spin",
-]
-
-[[package]]
 name = "burn-jit"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f30801b8a84f88bd49861ec9d70f4ad86e56340128a914c04c21d76e43e551e"
+version = "0.13.1"
 dependencies = [
  "burn-common",
  "burn-compute",
- "burn-fusion",
  "burn-tensor",
  "bytemuck",
  "derive-new",
@@ -345,9 +311,7 @@ dependencies = [
 
 [[package]]
 name = "burn-ndarray"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b88fc2a1244f2dbd9df295b82b106232666848894f1e0b694bd3a60fa8582b7"
+version = "0.13.1"
 dependencies = [
  "burn-autodiff",
  "burn-common",
@@ -363,23 +327,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "burn-tch"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcbfdd03dcd9ac305e4b006595f35bfdfe030a01e79b2f1a58a9c7ad2db91ca"
-dependencies = [
- "burn-tensor",
- "half",
- "libc",
- "rand",
- "tch",
-]
-
-[[package]]
 name = "burn-tensor"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac227ff0ff1e2ba2001795fdb76d011e33a952f4c9a9cd112207a23d4c43561"
+version = "0.13.1"
 dependencies = [
  "burn-common",
  "derive-new",
@@ -393,9 +342,7 @@ dependencies = [
 
 [[package]]
 name = "burn-train"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451a711918eaa8a33fe0682f6fefd6bf77f34a0a9c6437e6d7f87a8b0c3590f4"
+version = "0.13.1"
 dependencies = [
  "burn-core",
  "derive-new",
@@ -413,13 +360,10 @@ dependencies = [
 
 [[package]]
 name = "burn-wgpu"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a65a4ba31a4afb107a9a95e51636cc04f9b2a391f14210fb087f44fd05a1e91"
+version = "0.13.1"
 dependencies = [
  "burn-common",
  "burn-compute",
- "burn-fusion",
  "burn-jit",
  "burn-tensor",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,18 +14,18 @@ description = "FSRS for Rust, including Optimizer and Scheduler"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies.burn]
-version = "0.13.0"
+# version = "0.13.0"
 # git = "https://github.com/burn-rs/burn.git"
 # rev = "d2639682367f39d0d0ed049d0cf3a2077259e05d"
-path = "../burn/burn"
+path = "../burn/crates/burn"
 default-features = false
 features = ["std", "train", "ndarray", "autodiff", "wasm-sync", "browser"]
 
 [dev-dependencies.burn]
-version = "0.13.0"
+# version = "0.13.0"
 # git = "https://github.com/burn-rs/burn.git"
 # rev = "d2639682367f39d0d0ed049d0cf3a2077259e05d"
-path = "../burn/burn"
+path = "../burn/crates/burn"
 default-features = false
 features = ["std", "train", "ndarray", "sqlite-bundled"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "FSRS for Rust, including Optimizer and Scheduler"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies.burn]
-# version = "0.11.1"
+version = "0.13.0"
 # git = "https://github.com/burn-rs/burn.git"
 # rev = "d2639682367f39d0d0ed049d0cf3a2077259e05d"
 path = "../burn/burn"
@@ -22,7 +22,7 @@ default-features = false
 features = ["std", "train", "ndarray", "autodiff", "wasm-sync", "browser"]
 
 [dev-dependencies.burn]
-# version = "0.11.1"
+version = "0.13.0"
 # git = "https://github.com/burn-rs/burn.git"
 # rev = "d2639682367f39d0d0ed049d0cf3a2077259e05d"
 path = "../burn/burn"

--- a/src/batch_shuffle.rs
+++ b/src/batch_shuffle.rs
@@ -1,6 +1,7 @@
 use burn::data::{
     dataloader::{
-        batcher::Batcher, BatchStrategy, DataLoader, DataLoaderIterator, FixBatchStrategy, Progress,
+        batcher::DynBatcher, BatchStrategy, DataLoader, DataLoaderIterator, FixBatchStrategy,
+        Progress,
     },
     dataset::Dataset,
 };
@@ -77,7 +78,7 @@ impl Dataset<FSRSItem> for BatchShuffledDataset<FSRSItem> {
 pub(crate) struct BatchShuffledDataLoader<I, O> {
     strategy: Box<dyn BatchStrategy<I>>,
     dataset: Arc<FSRSDataset>,
-    batcher: Arc<dyn Batcher<I, O>>,
+    batcher: Box<dyn DynBatcher<I, O>>,
     rng: Mutex<rand::rngs::StdRng>,
     batch_size: usize,
 }
@@ -99,7 +100,7 @@ impl<I, O> BatchShuffledDataLoader<I, O> {
     pub fn new(
         strategy: Box<dyn BatchStrategy<I>>,
         dataset: Arc<FSRSDataset>,
-        batcher: Arc<dyn Batcher<I, O>>,
+        batcher: Box<dyn DynBatcher<I, O>>,
         rng: rand::rngs::StdRng,
         batch_size: usize,
     ) -> Self {
@@ -118,11 +119,10 @@ struct BatchShuffledDataloaderIterator<I, O> {
     current_index: usize,
     strategy: Box<dyn BatchStrategy<I>>,
     dataset: Arc<dyn Dataset<I>>,
-    batcher: Arc<dyn Batcher<I, O>>,
+    batcher: Box<dyn DynBatcher<I, O>>,
 }
 
-impl<I: Send + Sync + Clone + 'static, O: Send + Sync> DataLoader<O>
-    for BatchShuffledDataLoader<I, O>
+impl<I: Send + Sync + Clone + 'static, O: Send> DataLoader<O> for BatchShuffledDataLoader<I, O>
 where
     BatchShuffledDataset<I>: Dataset<I>,
 {
@@ -136,9 +136,9 @@ where
             self.rng.lock().unwrap().sample(Standard),
         ));
         Box::new(BatchShuffledDataloaderIterator::new(
-            self.strategy.new_like(),
+            self.strategy.clone_dyn(),
             dataset,
-            self.batcher.clone(),
+            self.batcher.clone_dyn(),
         ))
     }
 
@@ -165,7 +165,7 @@ where
     pub fn new(
         strategy: Box<dyn BatchStrategy<I>>,
         dataset: Arc<BatchShuffledDataset<I>>,
-        batcher: Arc<dyn Batcher<I, O>>,
+        batcher: Box<dyn DynBatcher<I, O>>,
     ) -> Self {
         Self {
             current_index: 0,
@@ -207,14 +207,14 @@ impl<I, O> DataLoaderIterator<O> for BatchShuffledDataloaderIterator<I, O> {
 }
 
 /// A builder for data loaders.
-pub(crate) struct BatchShuffledDataLoaderBuilder<I, O> {
-    batcher: Arc<dyn Batcher<I, O>>,
+pub struct BatchShuffledDataLoaderBuilder<I, O> {
+    batcher: Box<dyn DynBatcher<I, O>>,
 }
 
 impl<I, O> BatchShuffledDataLoaderBuilder<I, O>
 where
     I: Send + Sync + Clone + std::fmt::Debug + 'static,
-    O: Send + Sync + Clone + std::fmt::Debug + 'static,
+    O: Send + Clone + std::fmt::Debug + 'static,
     BatchShuffledDataset<I>: Dataset<I>,
 {
     /// Creates a new data loader builder.
@@ -228,10 +228,10 @@ where
     /// The data loader builder.
     pub fn new<B>(batcher: B) -> Self
     where
-        B: Batcher<I, O> + 'static,
+        B: DynBatcher<I, O> + 'static,
     {
         Self {
-            batcher: Arc::new(batcher),
+            batcher: Box::new(batcher),
         }
     }
 

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -50,6 +50,7 @@ impl FSRSItem {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct FSRSBatcher<B: Backend> {
     device: B::Device,
 }

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -434,7 +434,7 @@ mod tests {
         assert_eq!(
             fsrs.memory_state(item, None).unwrap(),
             MemoryState {
-                stability: 43.055424,
+                stability: 43.05542,
                 difficulty: 7.7609
             }
         );
@@ -541,7 +541,7 @@ mod tests {
                 },
                 good: ItemState {
                     memory: MemoryState {
-                        stability: 43.055424,
+                        stability: 43.05542,
                         difficulty: 7.7609
                     },
                     interval: 43

--- a/src/model.rs
+++ b/src/model.rs
@@ -49,7 +49,7 @@ impl<B: Backend> Model<B> {
             .collect();
 
         Self {
-            w: Param::from(Tensor::from_floats(
+            w: Param::from_tensor(Tensor::from_floats(
                 Data::new(initial_params, Shape { dims: [17] }),
                 &B::Device::default(),
             )),
@@ -243,7 +243,7 @@ impl<B: Backend> FSRS<B> {
 pub(crate) fn parameters_to_model<B: Backend>(parameters: &Parameters) -> Model<B> {
     let config = ModelConfig::default();
     let mut model = Model::new(config);
-    model.w = Param::from(Tensor::from_floats(
+    model.w = Param::from_tensor(Tensor::from_floats(
         Data::new(clip_parameters(parameters), Shape { dims: [17] }),
         &B::Device::default(),
     ));
@@ -271,7 +271,7 @@ mod tests {
         let retention = model.power_forgetting_curve(delta_t, stability);
         assert_eq!(
             retention.to_data(),
-            Data::from([1.0, 0.946059, 0.9299294, 0.9221679, 0.9, 0.79394597])
+            Data::from([1.0, 0.946059, 0.9299294, 0.9221679, 0.90000004, 0.79394597])
         )
     }
 
@@ -358,13 +358,13 @@ mod tests {
         s_recall.clone().backward();
         assert_eq!(
             s_recall.to_data(),
-            Data::from([26.980936, 14.128489, 63.600677, 208.72739])
+            Data::from([26.980938, 14.128489, 63.600677, 208.72739])
         );
         let s_forget = model.stability_after_failure(stability, difficulty, retention);
         s_forget.clone().backward();
         assert_eq!(
             s_forget.to_data(),
-            Data::from([1.9016013, 2.0777826, 2.3257504, 2.6291647])
+            Data::from([1.9016013, 2.0777824, 2.3257504, 2.6291647])
         );
         let next_stability = s_recall.mask_where(rating.clone().equal_elem(1), s_forget);
         next_stability.clone().backward();

--- a/src/training.rs
+++ b/src/training.rs
@@ -388,7 +388,7 @@ fn train<B: AutodiffBackend>(
             }
             let grads = GradientsParams::from_grads(gradients, &model);
             model = optim.step(lr, model, grads);
-            model.w = Param::from(weight_clipper(model.w.val()));
+            model.w = Param::from_tensor(weight_clipper(model.w.val()));
             // info!("epoch: {:?} iteration: {:?} lr: {:?}", epoch, iteration, lr);
             renderer.render_train(TrainingProgress {
                 progress,


### PR DESCRIPTION
With this PR and [the other](https://github.com/open-spaced-repetition/burn/pull/2), fsrs-browser passes its tests.