### PR TITLE
Remove sqrt from count in pretrain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "fsrs"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "burn",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsrs"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Open Spaced Repetition"]
 categories = ["algorithms", "science"]
 edition = "2021"

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -22,8 +22,8 @@ pub type Parameters = [f32];
 use itertools::izip;
 
 pub static DEFAULT_PARAMETERS: [f32; 17] = [
-    0.5701, 1.4436, 4.1386, 10.9355, 5.1443, 1.2006, 0.8627, 0.0362, 1.629, 0.1342, 1.0166, 2.1174,
-    0.0839, 0.3204, 1.4676, 0.219, 2.8237,
+    0.4872, 1.4003, 3.7145, 13.8206, 5.1618, 1.2298, 0.8975, 0.031, 1.6474, 0.1367, 1.0461, 2.1072,
+    0.0793, 0.3246, 1.587, 0.2272, 2.8755,
 ];
 
 fn infer<B: Backend>(
@@ -477,7 +477,7 @@ mod tests {
         let metrics = fsrs.evaluate(items.clone(), |_| true).unwrap();
 
         Data::from([metrics.log_loss, metrics.rmse_bins])
-            .assert_approx_eq(&Data::from([0.203_888, 0.029_732]), 5);
+            .assert_approx_eq(&Data::from([0.204_330, 0.031_510]), 5);
 
         let fsrs = FSRS::new(Some(PARAMETERS))?;
         let metrics = fsrs.evaluate(items.clone(), |_| true).unwrap();
@@ -490,7 +490,7 @@ mod tests {
             .unwrap();
 
         Data::from([self_by_other, other_by_self])
-            .assert_approx_eq(&Data::from([0.014_089, 0.016_483]), 5);
+            .assert_approx_eq(&Data::from([0.013_520, 0.019_003]), 5);
         Ok(())
     }
 
@@ -577,7 +577,7 @@ mod tests {
             fsrs.memory_state_from_sm2(2.5, 10.0, 0.9).unwrap(),
             MemoryState {
                 stability: 9.999995,
-                difficulty: 7.255334
+                difficulty: 7.4120417
             }
         );
         assert_eq!(

--- a/src/model.rs
+++ b/src/model.rs
@@ -283,7 +283,14 @@ mod tests {
         let stability = model.init_stability(rating);
         assert_eq!(
             stability.to_data(),
-            Data::from([0.5701, 1.4436, 4.1386, 10.9355, 0.5701, 1.4436])
+            Data::from([
+                DEFAULT_PARAMETERS[0],
+                DEFAULT_PARAMETERS[1],
+                DEFAULT_PARAMETERS[2],
+                DEFAULT_PARAMETERS[3],
+                DEFAULT_PARAMETERS[0],
+                DEFAULT_PARAMETERS[1]
+            ])
         )
     }
 
@@ -295,7 +302,14 @@ mod tests {
         let difficulty = model.init_difficulty(rating);
         assert_eq!(
             difficulty.to_data(),
-            Data::from([7.5455, 6.3449, 5.1443, 3.9436998, 7.5455, 6.3449])
+            Data::from([
+                DEFAULT_PARAMETERS[4] + 2.0 * DEFAULT_PARAMETERS[5],
+                DEFAULT_PARAMETERS[4] + DEFAULT_PARAMETERS[5],
+                DEFAULT_PARAMETERS[4],
+                DEFAULT_PARAMETERS[4] - DEFAULT_PARAMETERS[5],
+                DEFAULT_PARAMETERS[4] + 2.0 * DEFAULT_PARAMETERS[5],
+                DEFAULT_PARAMETERS[4] + DEFAULT_PARAMETERS[5]
+            ])
         )
     }
 
@@ -331,13 +345,18 @@ mod tests {
         next_difficulty.clone().backward();
         assert_eq!(
             next_difficulty.to_data(),
-            Data::from([6.7254, 5.8627, 5.0, 4.1373])
+            Data::from([
+                5.0 + 2.0 * DEFAULT_PARAMETERS[6],
+                5.0 + DEFAULT_PARAMETERS[6],
+                5.0,
+                5.0 - DEFAULT_PARAMETERS[6]
+            ])
         );
         let next_difficulty = model.mean_reversion(next_difficulty);
         next_difficulty.clone().backward();
         assert_eq!(
             next_difficulty.to_data(),
-            Data::from([6.6681643, 5.836694, 5.0052238, 4.1737533])
+            Data::from([6.744371, 5.8746934, 5.005016, 4.1353383])
         )
     }
 
@@ -358,19 +377,19 @@ mod tests {
         s_recall.clone().backward();
         assert_eq!(
             s_recall.to_data(),
-            Data::from([26.980938, 14.128489, 63.600677, 208.72739])
+            Data::from([27.980768, 14.916422, 66.45966, 222.94603])
         );
         let s_forget = model.stability_after_failure(stability, difficulty, retention);
         s_forget.clone().backward();
         assert_eq!(
             s_forget.to_data(),
-            Data::from([1.9016013, 2.0777824, 2.3257504, 2.6291647])
+            Data::from([1.9482934, 2.161251, 2.4528089, 2.8098207])
         );
         let next_stability = s_recall.mask_where(rating.clone().equal_elem(1), s_forget);
         next_stability.clone().backward();
         assert_eq!(
             next_stability.to_data(),
-            Data::from([1.9016013, 14.128489, 63.600677, 208.72739])
+            Data::from([1.9482934, 14.916422, 66.45966, 222.94603])
         )
     }
 

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -607,7 +607,7 @@ mod tests {
         );
         assert_eq!(
             memorized_cnt_per_day[memorized_cnt_per_day.len() - 1],
-            3130.8465582271774
+            3199.9526251977177
         )
     }
 
@@ -663,8 +663,8 @@ mod tests {
         assert_eq!(
             results.1.to_vec(),
             vec![
-                0, 16, 27, 34, 84, 80, 91, 92, 103, 107, 111, 113, 138, 132, 133, 116, 134, 148,
-                152, 162, 172, 177, 188, 189, 200, 185, 185, 200, 198, 200
+                0, 16, 27, 34, 84, 80, 91, 92, 104, 106, 109, 112, 133, 123, 139, 121, 136, 149,
+                136, 159, 173, 178, 175, 180, 189, 181, 196, 200, 193, 196
             ]
         );
         assert_eq!(
@@ -687,7 +687,7 @@ mod tests {
             ..Default::default()
         };
         let optimal_retention = fsrs.optimal_retention(&config, &[], |_v| true).unwrap();
-        assert_eq!(optimal_retention, 0.8263932);
+        assert_eq!(optimal_retention, 0.8419900928572013);
         assert!(fsrs.optimal_retention(&config, &[1.], |_v| true).is_err());
         Ok(())
     }

--- a/src/pre_training.rs
+++ b/src/pre_training.rs
@@ -100,8 +100,8 @@ fn loss(
     let y_pred = power_forgetting_curve(delta_t, init_s0);
     let logloss = (-(recall * y_pred.clone().mapv_into(|v| v.ln())
         + (1.0 - recall) * (1.0 - &y_pred).mapv_into(|v| v.ln()))
-        * count.mapv(|v| v.sqrt()))
-    .sum();
+        * count)
+        .sum();
     let l1 = (init_s0 - default_s0).abs() / 16.0;
     logloss + l1
 }
@@ -293,11 +293,9 @@ mod tests {
         let count = Array1::from(vec![435.0, 97.0, 63.0, 38.0, 28.0]);
         let default_s0 = DEFAULT_PARAMETERS[0] as f64;
         let actual = loss(&delta_t, &recall, &count, 1.017056, default_s0);
-        dbg!(actual);
-        assert_eq!(actual, 22.922578338789826);
+        assert_eq!(actual, 280.7447802452844);
         let actual = loss(&delta_t, &recall, &count, 1.017011, default_s0);
-        dbg!(actual);
-        assert_eq!(actual, 22.922578344493953);
+        assert_eq!(actual, 280.7444462249327);
     }
 
     #[test]
@@ -335,7 +333,7 @@ mod tests {
         )]);
         let actual = search_parameters(pretrainset, 0.9430285915990116);
         Data::from([*actual.get(&first_rating).unwrap()])
-            .assert_approx_eq(&Data::from([1.017_056]), 6);
+            .assert_approx_eq(&Data::from([0.908_688]), 6);
     }
 
     #[test]
@@ -347,10 +345,8 @@ mod tests {
         (pretrainset, trainset) = filter_outlier(pretrainset, trainset);
         let items = [pretrainset.clone(), trainset].concat();
         let average_recall = calculate_average_recall(&items);
-        Data::from(pretrain(pretrainset, average_recall).unwrap()).assert_approx_eq(
-            &Data::from([1.017_056, 1.829_625, 4.414_563, 10.935_500]),
-            6,
-        )
+        Data::from(pretrain(pretrainset, average_recall).unwrap())
+            .assert_approx_eq(&Data::from([0.908_688, 1.678_973, 4.216_837, 9.615_904]), 6)
     }
 
     #[test]
@@ -363,6 +359,6 @@ mod tests {
         let mut rating_stability = HashMap::from([(2, 0.35)]);
         let rating_count = HashMap::from([(2, 1)]);
         let actual = smooth_and_fill(&mut rating_stability, &rating_count).unwrap();
-        assert_eq!(actual, [0.13822041, 0.35, 1.0034012, 2.6513057,]);
+        assert_eq!(actual, [0.1217739, 0.35, 0.928426, 3.4544096]);
     }
 }


### PR DESCRIPTION
The modification in python optimizer: https://github.com/open-spaced-repetition/fsrs-optimizer/pull/106

~Waiting for benchmarking.~

The benchmark result: it reduce RMSE(bins) from 0.059 to 0.058.

For details: https://github.com/open-spaced-repetition/srs-benchmark/commit/ee3a3de0ded934132a97f234ea464bb4de9e01f5

Due to #185 and https://github.com/open-spaced-repetition/fsrs-browser/issues/23, I'm considering downgrade to burn 0.12.1. But I'm afraid it would mess up the commit history and the merge back in the future.

Fine. I decide to wait for the patch of burn.