### PR TITLE
update to nightly-2023-12-21

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # older versions may fail to compile; newer versions may fail the clippy tests
-channel = "nightly-2023-12-21"
+channel = "nightly-2024-07-26"     # If you're here due to a merge conflict, you probably want to change this to the latest nightly. See https://github.com/open-spaced-repetition/fsrs-browser#updating-the-git-submodules
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Ulgh I force-pushed to my repo and thought I force pushed to this repo [and erroneously declared victory](https://github.com/open-spaced-repetition/fsrs-rs/pull/205#issuecomment-2254641483) since CICD passed. I think github internally stores everything in the same git repo since clicking this

![image](https://github.com/user-attachments/assets/8b4ceca4-8252-422b-a27c-d02e780c4aef)

takes you [here](https://github.com/open-spaced-repetition/fsrs-rs/tree/ed628b09c5889e870e70c01f89ac1526325583d8) which _doesn't exist_, but *does* exist on [my repo](https://github.com/AlexErrant/fsrs-rs/commit/ed628b09c5889e870e70c01f89ac1526325583d8).

Very, very confusing. Anyway it seems like I accidentally git-submoduled _my repo_ instead of _this repo_... but it still works because Github is [trash at security](https://trufflesecurity.com/blog/anyone-can-access-deleted-and-private-repo-data-github) . This is more or less an accidental [insecure direct object reference attack](https://cheatsheetseries.owasp.org/cheatsheets/Insecure_Direct_Object_Reference_Prevention_Cheat_Sheet.html), but with two public repos (instead of 2 private ones). Gotta love security. (From one repo, I can directly access the git-objects of another repo, just because it's a fork.)

Also, it turns out I don't have permissions to force-push the `fsrs-browser` branch, so we can either merge or someone else can force-push the `fsrs-browser` branch to the [`ed628b09c5889e870e70c01f89ac1526325583d8`](https://github.com/AlexErrant/fsrs-rs/commit/ed628b09c5889e870e70c01f89ac1526325583d8) hash.