### PR TITLE
Change the R_MAX of CMRR.rs

### DIFF
--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -56,7 +56,7 @@ impl From<Column> for SliceInfoElem {
 }
 
 const R_MIN: f32 = 0.75;
-const R_MAX: f32 = 0.95;
+const R_MAX: f32 = 0.98;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SimulatorConfig {

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -1118,7 +1118,7 @@ mod tests {
             ..Default::default()
         };
         let optimal_retention = fsrs.optimal_retention(&config, &[], |_v| true).unwrap();
-        assert_eq!(optimal_retention, 0.7921062);
+        assert_eq!(optimal_retention, 0.8378522);
         assert!(fsrs.optimal_retention(&config, &[1.], |_v| true).is_err());
         Ok(())
     }
@@ -1138,7 +1138,7 @@ mod tests {
         let optimal_retention = fsrs
             .optimal_retention(&config, &DEFAULT_PARAMETERS[..17], |_v| true)
             .unwrap();
-        assert_eq!(optimal_retention, 0.8430037);
+        assert_eq!(optimal_retention, 0.8378522);
         Ok(())
     }
 


### PR DESCRIPTION
https://github.com/open-spaced-repetition/fsrs4anki/issues/686#issuecomment-2335482240
It appears that our previous estimates of optimal retention were underestimates. I think it makes sense to expand the range.
![image](https://github.com/user-attachments/assets/971f5387-6d45-44aa-ae79-71a6bae4294b)
Note that here it says "workload", but it's not just workload, it's workload/knowledge
