### PR TITLE
Revert the R_MAX change.rs

### DIFF
--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -56,7 +56,7 @@ impl From<Column> for SliceInfoElem {
 }
 
 const R_MIN: f32 = 0.75;
-const R_MAX: f32 = 0.98;
+const R_MAX: f32 = 0.95;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SimulatorConfig {


### PR DESCRIPTION
https://github.com/open-spaced-repetition/fsrs-rs/pull/219#issuecomment-2337800477
As it turns out, previous graphs weren't accurate. So the conclusion that previous values of CMRR are undersestimates is probably not true either. Therefore, I think we should revert the change. Or we could set R_MAX to 0.96 or 0.97.
EDIT: ok, to be honest, I'm confused. I'm losing track of what data is good and what isn't, and why loss aversion is 1 in some cases but 2.5 in other cases.