### PR TITLE
Fix/filter_outlier outputs dataset in arbitrary order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "fsrs"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "burn",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsrs"
-version = "1.2.2"
+version = "1.2.3"
 authors = ["Open Spaced Repetition"]
 categories = ["algorithms", "science"]
 edition = "2021"

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -6,6 +6,7 @@ use burn::{
     tensor::{backend::Backend, Data, ElementConversion, Float, Int, Shape, Tensor},
 };
 
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 /// Stores a list of reviews for a card, in chronological order. Each FSRSItem corresponds
@@ -190,7 +191,7 @@ pub fn filter_outlier(
     let mut filtered_items = vec![];
     let mut removed_pairs: [HashSet<_>; 5] = Default::default();
 
-    for (rating, delta_t_groups) in groups.into_iter() {
+    for (rating, delta_t_groups) in groups.into_iter().sorted_by_key(|&(k, _)| k) {
         let mut sub_groups = delta_t_groups.into_iter().collect::<Vec<_>>();
 
         // order by size of sub group ascending and delta_t descending


### PR DESCRIPTION
solve the problem described here: https://forums.ankiweb.net/t/anki-24-10-beta/49989/27?u=l.m.sherlock

summary: `filter_outlier` changes the order of the dataset arbitrarily. So the optimized parameters may varies each time.