### PR TITLE
Fix/filter rating_stability to match rating_count keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "fsrs"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "burn",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsrs"
-version = "1.2.3"
+version = "1.2.4"
 authors = ["Open Spaced Repetition"]
 categories = ["algorithms", "science"]
 edition = "2021"

--- a/src/pre_training.rs
+++ b/src/pre_training.rs
@@ -168,6 +168,7 @@ pub(crate) fn smooth_and_fill(
     rating_stability: &mut HashMap<u32, f32>,
     rating_count: &HashMap<u32, u32>,
 ) -> Result<[f32; 4]> {
+    rating_stability.retain(|&key, _| rating_count.contains_key(&key));
     for (small_rating, big_rating) in [(1, 2), (2, 3), (3, 4), (1, 3), (2, 4), (1, 4)] {
         if let (Some(&small_value), Some(&big_value)) = (
             rating_stability.get(&small_rating),


### PR DESCRIPTION
Prevents processing non-existent rating data, improving data consistency and avoiding potential errors when working with unmatched ratings.

Source: https://forums.ankiweb.net/t/anki-24-10-beta/49989/51?u=l.m.sherlock

Error:

```
[/Users/jarrettye/Codes/open-spaced-repetition/fsrs-rs/src/pre_training.rs:171:5] &rating_stability = {
    2: 0.9449276,
    1: 0.057034113,
    4: 0.7255576,
    3: 1.1028688,
}
[/Users/jarrettye/Codes/open-spaced-repetition/fsrs-rs/src/pre_training.rs:172:5] &rating_count = {
    2: 303,
    3: 567,
}
thread '<unnamed>' panicked at /Users/jarrettye/Codes/open-spaced-repetition/fsrs-rs/src/pre_training.rs:179:62:
no entry found for key
```