### PR TITLE
R_MIN = 0.70

### DIFF
--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -55,7 +55,7 @@ impl From<Column> for SliceInfoElem {
     }
 }
 
-const R_MIN: f32 = 0.75;
+const R_MIN: f32 = 0.70;
 const R_MAX: f32 = 0.95;
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -1127,7 +1127,7 @@ mod tests {
             ..Default::default()
         };
         let optimal_retention = fsrs.optimal_retention(&config, &[], |_v| true).unwrap();
-        assert_eq!(optimal_retention, 0.80994797);
+        assert_eq!(optimal_retention, 0.8277919);
         assert!(fsrs.optimal_retention(&config, &[1.], |_v| true).is_err());
         Ok(())
     }
@@ -1147,7 +1147,7 @@ mod tests {
         let optimal_retention = fsrs
             .optimal_retention(&config, &DEFAULT_PARAMETERS[..17], |_v| true)
             .unwrap();
-        assert_eq!(optimal_retention, 0.8435673);
+        assert_eq!(optimal_retention, 0.85450846);
         Ok(())
     }
 


### PR DESCRIPTION
I have tried the most recent beta: https://github.com/ankitects/anki/releases/tag/24.10beta2

CMRR values have gone down for every single one of my presets, meaning that the old values were overestimates. Out of 7 presets that I tried CMRR on, I got 0.75 for three of them, and 0.90 for only one of them.

@user1823, @brishtibheja I'd like you to optimize your parameters and try CMRR in Anki 24.10 beta 2. If your CMRR values are also only going down and not up, then it would imply that the range needs to be extended towards lower values.