### PR TITLE
Fix/sample_size should be continuous over learn_span

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "fsrs"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "burn",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsrs"
-version = "1.3.2"
+version = "1.3.3"
 authors = ["Open Spaced Repetition"]
 categories = ["algorithms", "science"]
 edition = "2021"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -19,7 +19,7 @@ pub(crate) fn calc_mem(inf: &FSRS, past_reviews: usize) -> MemoryState {
         rating: 3,
         delta_t: 21,
     };
-    let reviews = repeat(review.clone()).take(past_reviews + 1).collect_vec();
+    let reviews = repeat(review).take(past_reviews + 1).collect_vec();
     inf.memory_state(FSRSItem { reviews }, None).unwrap()
 }
 

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -404,16 +404,16 @@ impl<B: Backend> FSRS<B> {
         let tol = 0.01f32;
 
         let sample_size = match config.learn_span {
-            ..=30 => 90,
+            ..=30 => 180,
             31..365 => {
                 let (a1, a2, a3) = (8.20e-7, 2.41e-3, 1.30e-2);
                 let factor = (config.learn_span as f32)
                     .powf(2.0)
                     .mul_add(a1, config.learn_span as f32 * a2 + a3);
-                let default_sample_size = 8.0;
+                let default_sample_size = 16.0;
                 (default_sample_size / factor).round() as usize
             }
-            365.. => 8,
+            365.. => default_sample_size as usize,
         };
 
         let (xb, fb) = (

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -403,6 +403,7 @@ impl<B: Backend> FSRS<B> {
         let maxiter = 64;
         let tol = 0.01f32;
 
+        let default_sample_size = 16.0;
         let sample_size = match config.learn_span {
             ..=30 => 180,
             31..365 => {
@@ -410,7 +411,6 @@ impl<B: Backend> FSRS<B> {
                 let factor = (config.learn_span as f32)
                     .powf(2.0)
                     .mul_add(a1, config.learn_span as f32 * a2 + a3);
-                let default_sample_size = 16.0;
                 (default_sample_size / factor).round() as usize
             }
             365.. => default_sample_size as usize,

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -413,7 +413,7 @@ impl<B: Backend> FSRS<B> {
                 let default_sample_size = 8.0;
                 (default_sample_size / factor).round() as usize
             }
-            365.. => 16,
+            365.. => 8,
         };
 
         let (xb, fb) = (


### PR DESCRIPTION
It should be 8, not 16. Originally, the maximum sample size was 4. Since you doubled default_sample_size, this should also double.