### PR TITLE
Revert "remove pow polyfill"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "fsrs"
-version = "1.3.3"
+version = "1.3.4"
 dependencies = [
  "burn",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsrs"
-version = "1.3.3"
+version = "1.3.4"
 authors = ["Open Spaced Repetition"]
 categories = ["algorithms", "science"]
 edition = "2021"


### PR DESCRIPTION
Reverts open-spaced-repetition/fsrs-rs#195

The `into_scalar()` blocks the Backpropagation, which reset gradient to zero.

w[9], w[12] and w[13] are untrainable after the #195.

![w 9](https://github.com/user-attachments/assets/ed83cd72-486f-4dcb-bc1f-7acf8d31392c)

![w 12](https://github.com/user-attachments/assets/c08eba65-673a-42c7-9446-8bb6b53090de)

![w 13](https://github.com/user-attachments/assets/e6058cb3-40d9-49d1-a027-bd4793c43e8d)
