### PR TITLE
Fix/consider short term params when clipping post-lapse stability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "fsrs"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "burn",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsrs"
-version = "1.4.3"
+version = "1.4.4"
 authors = ["Open Spaced Repetition"]
 categories = ["algorithms", "science"]
 edition = "2021"

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -499,7 +499,7 @@ mod tests {
         let fsrs = FSRS::new(Some(&[]))?;
         let metrics = fsrs.evaluate(items.clone(), |_| true).unwrap();
 
-        assert_approx_eq([metrics.log_loss, metrics.rmse_bins], [0.216326, 0.038727]);
+        assert_approx_eq([metrics.log_loss, metrics.rmse_bins], [0.216286, 0.038692]);
 
         let fsrs = FSRS::new(Some(PARAMETERS))?;
         let metrics = fsrs.evaluate(items.clone(), |_| true).unwrap();
@@ -510,7 +510,7 @@ mod tests {
             .universal_metrics(items.clone(), &DEFAULT_PARAMETERS, |_| true)
             .unwrap();
 
-        assert_approx_eq([self_by_other, other_by_self], [0.016236, 0.031085]);
+        assert_approx_eq([self_by_other, other_by_self], [0.016570, 0.031037]);
 
         Ok(())
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -94,9 +94,10 @@ impl<B: Backend> Model<B> {
             * last_d.pow(-self.w.get(12))
             * ((last_s.clone() + 1).pow(self.w.get(13)) - 1)
             * ((-r + 1) * self.w.get(14)).exp();
+        let new_s_min = last_s / (self.w.get(17) * self.w.get(18)).exp();
         new_s
             .clone()
-            .mask_where(last_s.clone().lower(new_s), last_s)
+            .mask_where(new_s_min.clone().lower(new_s), new_s_min)
     }
 
     fn stability_short_term(&self, last_s: Tensor<B, 1>, rating: Tensor<B, 1>) -> Tensor<B, 1> {
@@ -380,7 +381,10 @@ mod tests {
             &device,
         );
         let state = model.forward(delta_ts, ratings, None);
-        dbg!(&state);
+        let stability = state.stability.to_data();
+        let difficulty = state.difficulty.to_data();
+        stability.assert_approx_eq(&Data::from([0.2619, 1.7074, 5.8691, 25.0124, 0.2859, 2.1482]), 4);
+        difficulty.assert_approx_eq(&Data::from([8.0827, 7.0405, 5.2729, 2.1301, 8.0827, 7.0405]), 4);
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -383,8 +383,14 @@ mod tests {
         let state = model.forward(delta_ts, ratings, None);
         let stability = state.stability.to_data();
         let difficulty = state.difficulty.to_data();
-        stability.assert_approx_eq(&Data::from([0.2619, 1.7074, 5.8691, 25.0124, 0.2859, 2.1482]), 4);
-        difficulty.assert_approx_eq(&Data::from([8.0827, 7.0405, 5.2729, 2.1301, 8.0827, 7.0405]), 4);
+        stability.assert_approx_eq(
+            &Data::from([0.2619, 1.7074, 5.8691, 25.0124, 0.2859, 2.1482]),
+            4,
+        );
+        difficulty.assert_approx_eq(
+            &Data::from([8.0827, 7.0405, 5.2729, 2.1301, 8.0827, 7.0405]),
+            4,
+        );
     }
 
     #[test]

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -83,7 +83,7 @@ fn stability_after_success(w: &[f32], s: f32, r: f32, d: f32, rating: usize) -> 
 
 fn stability_after_failure(w: &[f32], s: f32, r: f32, d: f32) -> f32 {
     (w[11] * d.powf(-w[12]) * ((s + 1.0).powf(w[13]) - 1.0) * f32::exp((1.0 - r) * w[14]))
-        .clamp(S_MIN, s)
+        .clamp(S_MIN, s / (w[17] * w[18]).exp())
 }
 
 fn stability_short_term(w: &[f32], s: f32, rating_offset: f32, session_len: f32) -> f32 {
@@ -903,7 +903,7 @@ mod tests {
             simulate(&config, &DEFAULT_PARAMETERS, 0.9, None, None)?;
         assert_eq!(
             memorized_cnt_per_day[memorized_cnt_per_day.len() - 1],
-            6919.944
+            6911.91
         );
         Ok(())
     }
@@ -1023,7 +1023,7 @@ mod tests {
             ..Default::default()
         };
         let results = simulate(&config, &DEFAULT_PARAMETERS, 0.9, None, None)?;
-        assert_eq!(results.0[results.0.len() - 1], 6591.4854);
+        assert_eq!(results.0[results.0.len() - 1], 6559.517);
         Ok(())
     }
 
@@ -1076,7 +1076,7 @@ mod tests {
             ..Default::default()
         };
         let optimal_retention = fsrs.optimal_retention(&config, &[], |_v| true).unwrap();
-        assert_eq!(optimal_retention, 0.84499365);
+        assert_eq!(optimal_retention, 0.84458643);
         assert!(fsrs.optimal_retention(&config, &[1.], |_v| true).is_err());
         Ok(())
     }


### PR DESCRIPTION
refer to:
- https://github.com/open-spaced-repetition/fsrs-optimizer/pull/150

benchmark result:

```
Model: FSRS-rs-new
Total number of users: 9999
Total number of reviews: 349923850
Weighted average by reviews:
FSRS-rs LogLoss (mean±std): 0.3276±0.1524
FSRS-rs RMSE(bins) (mean±std): 0.0517±0.0333
FSRS-rs AUC (mean±std): 0.7003±0.0780

Weighted average by log(reviews):
FSRS-rs LogLoss (mean±std): 0.3532±0.1694
FSRS-rs RMSE(bins) (mean±std): 0.0710±0.0461
FSRS-rs AUC (mean±std): 0.6991±0.0884

Weighted average by users:
FSRS-rs LogLoss (mean±std): 0.3565±0.1719
FSRS-rs RMSE(bins) (mean±std): 0.0739±0.0478
FSRS-rs AUC (mean±std): 0.6983±0.0904

parameters: [0.4364, 1.1666, 3.2263, 15.8143, 7.1405, 0.5257, 1.7751, 0.0102, 1.5151, 0.1304, 1.0091, 1.9183, 0.1034, 0.3016, 2.3447, 0.2315, 3.0099, 0.4436, 0.6239]

Model: FSRS-rs-old
Total number of users: 9999
Total number of reviews: 349923850
Weighted average by reviews:
FSRS-rs-1 LogLoss (mean±std): 0.3271±0.1521
FSRS-rs-1 RMSE(bins) (mean±std): 0.0512±0.0331
FSRS-rs-1 AUC (mean±std): 0.7014±0.0778

Weighted average by log(reviews):
FSRS-rs-1 LogLoss (mean±std): 0.3528±0.1691
FSRS-rs-1 RMSE(bins) (mean±std): 0.0705±0.0460
FSRS-rs-1 AUC (mean±std): 0.7001±0.0885

Weighted average by users:
FSRS-rs-1 LogLoss (mean±std): 0.3561±0.1716
FSRS-rs-1 RMSE(bins) (mean±std): 0.0734±0.0478
FSRS-rs-1 AUC (mean±std): 0.6992±0.0905

parameters: [0.4127, 1.1488, 3.1878, 15.8143, 7.1333, 0.5271, 1.7733, 0.0084, 1.5148, 0.1191, 1.003, 1.9051, 0.1122, 0.2962, 2.3266, 0.2272, 3.0122, 0.5077, 0.6404]
```