### PR TITLE
Feat/option enable_short_term in training

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "fsrs"
-version = "1.4.4"
+version = "1.5.0"
 dependencies = [
  "burn",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "fsrs"
-version = "1.5.0"
+version = "2.0.0"
 dependencies = [
  "burn",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsrs"
-version = "1.5.0"
+version = "2.0.0"
 authors = ["Open Spaced Repetition"]
 categories = ["algorithms", "science"]
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsrs"
-version = "1.4.4"
+version = "1.5.0"
 authors = ["Open Spaced Repetition"]
 categories = ["algorithms", "science"]
 edition = "2021"

--- a/examples/optimize.rs
+++ b/examples/optimize.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Default parameters: {:?}", DEFAULT_PARAMETERS);
 
     // Optimize the FSRS model using the created items
-    let optimized_parameters = fsrs.compute_parameters(fsrs_items, None)?;
+    let optimized_parameters = fsrs.compute_parameters(fsrs_items, None, false)?;
 
     println!("Optimized parameters: {:?}", optimized_parameters);
 

--- a/examples/optimize.rs
+++ b/examples/optimize.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Default parameters: {:?}", DEFAULT_PARAMETERS);
 
     // Optimize the FSRS model using the created items
-    let optimized_parameters = fsrs.compute_parameters(fsrs_items, None, false)?;
+    let optimized_parameters = fsrs.compute_parameters(fsrs_items, None)?;
 
     println!("Optimized parameters: {:?}", optimized_parameters);
 

--- a/src/training.rs
+++ b/src/training.rs
@@ -77,6 +77,16 @@ impl<B: AutodiffBackend> Model<B> {
         self.w.grad_replace(&mut grad, updated_grad_tensor);
         grad
     }
+
+    fn free_short_term_stability(&self, mut grad: B::Gradients) -> B::Gradients {
+        let grad_tensor = self.w.grad(&grad).unwrap();
+        let updated_grad_tensor =
+            grad_tensor.slice_assign([17..19], Tensor::zeros([2], &B::Device::default()));
+
+        self.w.grad_remove(&mut grad);
+        self.w.grad_replace(&mut grad, updated_grad_tensor);
+        grad
+    }
 }
 
 #[derive(Debug, Default, Clone)]
@@ -196,6 +206,7 @@ impl<B: Backend> FSRS<B> {
         &self,
         train_set: Vec<FSRSItem>,
         progress: Option<Arc<Mutex<CombinedProgressState>>>,
+        enable_short_term: bool,
     ) -> Result<Vec<f32>> {
         let finish_progress = || {
             if let Some(progress) = &progress {
@@ -229,8 +240,9 @@ impl<B: Backend> FSRS<B> {
         }
         let config = TrainingConfig::new(
             ModelConfig {
-                freeze_stability: false,
+                freeze_initial_stability: !enable_short_term,
                 initial_stability: Some(initial_stability),
+                freeze_short_term_stability: !enable_short_term,
             },
             AdamConfig::new().with_epsilon(1e-8),
         );
@@ -290,7 +302,7 @@ impl<B: Backend> FSRS<B> {
         Ok(optimized_parameters)
     }
 
-    pub fn benchmark(&self, mut train_set: Vec<FSRSItem>) -> Vec<f32> {
+    pub fn benchmark(&self, mut train_set: Vec<FSRSItem>, enable_short_term: bool) -> Vec<f32> {
         let average_recall = calculate_average_recall(&train_set);
         let (pre_train_set, _next_train_set) = train_set
             .clone()
@@ -299,8 +311,9 @@ impl<B: Backend> FSRS<B> {
         let initial_stability = pretrain(pre_train_set, average_recall).unwrap().0;
         let config = TrainingConfig::new(
             ModelConfig {
-                freeze_stability: false,
+                freeze_initial_stability: !enable_short_term,
                 initial_stability: Some(initial_stability),
+                freeze_short_term_stability: !enable_short_term,
             },
             AdamConfig::new().with_epsilon(1e-8),
         );
@@ -368,8 +381,11 @@ fn train<B: AutodiffBackend>(
                 Reduction::Sum,
             );
             let mut gradients = loss.backward();
-            if model.config.freeze_stability {
+            if model.config.freeze_initial_stability {
                 gradients = model.freeze_initial_stability(gradients);
+            }
+            if model.config.freeze_short_term_stability {
+                gradients = model.free_short_term_stability(gradients);
             }
             let grads = GradientsParams::from_grads(gradients, &model);
             model = optim.step(lr, model, grads);
@@ -649,26 +665,30 @@ mod tests {
                 .unwrap();
         }
         for items in [anki21_sample_file_converted_to_fsrs(), data_from_csv()] {
-            let progress = CombinedProgressState::new_shared();
-            let progress2 = Some(progress.clone());
-            thread::spawn(move || {
-                let mut finished = false;
-                while !finished {
-                    thread::sleep(Duration::from_millis(500));
-                    let guard = progress.lock().unwrap();
-                    finished = guard.finished();
-                    println!("progress: {}/{}", guard.current(), guard.total());
-                }
-            });
+            for enable_short_term in [true, false] {
+                let progress = CombinedProgressState::new_shared();
+                let progress2 = Some(progress.clone());
+                thread::spawn(move || {
+                    let mut finished = false;
+                    while !finished {
+                        thread::sleep(Duration::from_millis(500));
+                        let guard = progress.lock().unwrap();
+                        finished = guard.finished();
+                        println!("progress: {}/{}", guard.current(), guard.total());
+                    }
+                });
 
-            let fsrs = FSRS::new(Some(&[])).unwrap();
-            let parameters = fsrs.compute_parameters(items.clone(), progress2).unwrap();
-            dbg!(&parameters);
+                let fsrs = FSRS::new(Some(&[])).unwrap();
+                let parameters = fsrs
+                    .compute_parameters(items.clone(), progress2, enable_short_term)
+                    .unwrap();
+                dbg!(&parameters);
 
-            // evaluate
-            let model = FSRS::new(Some(&parameters)).unwrap();
-            let metrics = model.evaluate(items, |_| true).unwrap();
-            dbg!(&metrics);
+                // evaluate
+                let model = FSRS::new(Some(&parameters)).unwrap();
+                let metrics = model.evaluate(items.clone(), |_| true).unwrap();
+                dbg!(&metrics);
+            }
         }
     }
 }

--- a/src/training.rs
+++ b/src/training.rs
@@ -201,8 +201,24 @@ pub fn calculate_average_recall(items: &[FSRSItem]) -> f32 {
 }
 
 impl<B: Backend> FSRS<B> {
-    /// Calculate appropriate parameters for the provided review history.
     pub fn compute_parameters(
+        &self,
+        train_set: Vec<FSRSItem>,
+        progress: Option<Arc<Mutex<CombinedProgressState>>>,
+    ) -> Result<Vec<f32>> {
+        self.compute_parameters_inner(train_set, progress, true)
+    }
+
+    pub fn compute_parameters_disable_short_term(
+        &self,
+        train_set: Vec<FSRSItem>,
+        progress: Option<Arc<Mutex<CombinedProgressState>>>,
+    ) -> Result<Vec<f32>> {
+        self.compute_parameters_inner(train_set, progress, false)
+    }
+
+    /// Calculate appropriate parameters for the provided review history.
+    fn compute_parameters_inner(
         &self,
         train_set: Vec<FSRSItem>,
         progress: Option<Arc<Mutex<CombinedProgressState>>>,
@@ -302,7 +318,15 @@ impl<B: Backend> FSRS<B> {
         Ok(optimized_parameters)
     }
 
-    pub fn benchmark(&self, mut train_set: Vec<FSRSItem>, enable_short_term: bool) -> Vec<f32> {
+    pub fn benchmark(&self, train_set: Vec<FSRSItem>) -> Vec<f32> {
+        self.benchmark_inner(train_set, true)
+    }
+
+    pub fn benchmark_disable_short_term(&self, train_set: Vec<FSRSItem>) -> Vec<f32> {
+        self.benchmark_inner(train_set, false)
+    }
+
+    fn benchmark_inner(&self, mut train_set: Vec<FSRSItem>, enable_short_term: bool) -> Vec<f32> {
         let average_recall = calculate_average_recall(&train_set);
         let (pre_train_set, _next_train_set) = train_set
             .clone()
@@ -680,7 +704,7 @@ mod tests {
 
                 let fsrs = FSRS::new(Some(&[])).unwrap();
                 let parameters = fsrs
-                    .compute_parameters(items.clone(), progress2, enable_short_term)
+                    .compute_parameters_inner(items.clone(), progress2, enable_short_term)
                     .unwrap();
                 dbg!(&parameters);
 

--- a/src/training.rs
+++ b/src/training.rs
@@ -201,24 +201,8 @@ pub fn calculate_average_recall(items: &[FSRSItem]) -> f32 {
 }
 
 impl<B: Backend> FSRS<B> {
-    pub fn compute_parameters(
-        &self,
-        train_set: Vec<FSRSItem>,
-        progress: Option<Arc<Mutex<CombinedProgressState>>>,
-    ) -> Result<Vec<f32>> {
-        self.compute_parameters_inner(train_set, progress, true)
-    }
-
-    pub fn compute_parameters_disable_short_term(
-        &self,
-        train_set: Vec<FSRSItem>,
-        progress: Option<Arc<Mutex<CombinedProgressState>>>,
-    ) -> Result<Vec<f32>> {
-        self.compute_parameters_inner(train_set, progress, false)
-    }
-
     /// Calculate appropriate parameters for the provided review history.
-    fn compute_parameters_inner(
+    pub fn compute_parameters(
         &self,
         train_set: Vec<FSRSItem>,
         progress: Option<Arc<Mutex<CombinedProgressState>>>,
@@ -318,15 +302,7 @@ impl<B: Backend> FSRS<B> {
         Ok(optimized_parameters)
     }
 
-    pub fn benchmark(&self, train_set: Vec<FSRSItem>) -> Vec<f32> {
-        self.benchmark_inner(train_set, true)
-    }
-
-    pub fn benchmark_disable_short_term(&self, train_set: Vec<FSRSItem>) -> Vec<f32> {
-        self.benchmark_inner(train_set, false)
-    }
-
-    fn benchmark_inner(&self, mut train_set: Vec<FSRSItem>, enable_short_term: bool) -> Vec<f32> {
+    pub fn benchmark(&self, mut train_set: Vec<FSRSItem>, enable_short_term: bool) -> Vec<f32> {
         let average_recall = calculate_average_recall(&train_set);
         let (pre_train_set, _next_train_set) = train_set
             .clone()
@@ -704,7 +680,7 @@ mod tests {
 
                 let fsrs = FSRS::new(Some(&[])).unwrap();
                 let parameters = fsrs
-                    .compute_parameters_inner(items.clone(), progress2, enable_short_term)
+                    .compute_parameters(items.clone(), progress2, enable_short_term)
                     .unwrap();
                 dbg!(&parameters);
 


### PR DESCRIPTION
close #255 

The API is changed in this PR, but I don't want to release a version because #256 also requires a major change.

What's the best practice for this case?