### PR TITLE
Fix/memorization calculation and due date handling in simulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "fsrs"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "burn",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsrs"
-version = "1.4.8"
+version = "1.4.9"
 authors = ["Open Spaced Repetition"]
 categories = ["algorithms", "science"]
 edition = "2021"

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -228,7 +228,7 @@ pub fn simulate(
         // Guards
         if card.due >= learn_span as f32 {
             if !is_learn {
-                let delta_t = learn_span - last_date_index;
+                let delta_t = learn_span.max(last_date_index) - last_date_index;
                 let pre_sim_days = (-card.last_date) as usize;
                 for i in 0..delta_t {
                     memorized_cnt_per_day[last_date_index + i] +=


### PR DESCRIPTION
This PR addresses a critical bug in the memory retention calculation for existing review cards. The key issue was that we couldn't accurately predict when a card would be reviewed in the simulation (they could be delayed due to review limit), making the retention calculation based on due dates inaccurate. It also affects overdue cards during simulation.

Key Changes:

- Moved memory retention calculation to two specific points:
  1. When a card is actually reviewed in the simulation
  2. When a card exits the simulation (due date beyond simulation span)
- Fixed due date handling to prevent negative values (for existing cards)

Before:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/b51d29c0-842b-4796-8d3a-23835e01bccd" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/ecba6450-aafb-4e8f-ac33-dc761574705a" />


After:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/988526fa-13cb-4f97-a2b9-9ab6629d05e1" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/d8bb8962-0180-4db7-a4f2-75de45b65de1" />
