### PR TITLE
Fix/don't count new card in due_cnt_per_day

### DIFF
--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -381,11 +381,13 @@ pub fn simulate(
             (_, false) => todays_review + 1 > review_limit,
         } || (cost_per_day[day_index] + fail_cost > max_cost_perday)
         {
-            due_cnt_per_day[day_index] -= 1;
-            card.due = day_index as f32 + 1.0;
-            if card.due < learn_span as f32 {
-                due_cnt_per_day[card.due as usize] += 1;
+            if !is_learn {
+                due_cnt_per_day[day_index] -= 1;
+                if day_index + 1 < due_cnt_per_day.len() {
+                    due_cnt_per_day[day_index + 1] += 1;
+                }
             }
+            card.due = day_index as f32 + 1.0;
             card_priorities.change_priority(&card_index, card_priority(card, is_learn));
             continue;
         }


### PR DESCRIPTION
With `--release` flag, rust doesn't panic when you subtract with overflow on an unsigned type. Without it, the previous code cannot pass this test:
```
$ cargo test -- optimal_retention::tests::simulator --nocapture          
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.17s
     Running unittests src/lib.rs (target/debug/deps/fsrs-3f5f0d8a3b3ba5f6)

running 2 tests
test optimal_retention::tests::simulator_learn_review_costs ... ok
thread 'optimal_retention::tests::simulator' panicked at src/optimal_retention.rs:385:22:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test optimal_retention::tests::simulator ... FAILED

failures:

failures:
    optimal_retention::tests::simulator

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 48 filtered out; finished in 0.01s
```

This PR doesn't change the behavior of the `simulate` function in all related tests, so I won't update the version.