### PR TITLE
Refactor/provide a hook for post scheduling adjustments in simulator configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "fsrs"
-version = "2.0.4"
+version = "3.0.0"
 dependencies = [
  "burn",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsrs"
-version = "2.0.4"
+version = "3.0.0"
 authors = ["Open Spaced Repetition"]
 categories = ["algorithms", "science"]
 edition = "2021"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub use inference::{
 };
 pub use model::FSRS;
 pub use optimal_retention::{
-    extract_simulator_config, simulate, Card, RevlogEntry, RevlogReviewKind, SimulatorConfig,
+    extract_simulator_config, simulate, Card, PostSchedulingFn, RevlogEntry, RevlogReviewKind,
+    SimulatorConfig,
 };
 pub use training::CombinedProgressState;

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -44,7 +44,7 @@ pub type PostSchedulingFnInner =
 pub struct PostSchedulingFn(pub Box<PostSchedulingFnInner>);
 
 impl PartialEq for PostSchedulingFn {
-    fn eq(&self, _other: &Self) -> bool {
+    fn eq(&self, _: &Self) -> bool {
         true
     }
 }


### PR DESCRIPTION
This PR introduces several significant changes to the simulator configuration and interval scheduling mechanism:

### Major Changes
1. Replaced `ndarray::Array1` with standard `Vec` for simulation result storage
2. Added customizable post-scheduling functionality through a new `PostSchedulingFn` type
3. Removed built-in fuzzing logic in favor of configurable post-scheduling
4. Added manual implementations for `PartialEq` and `Debug` for `SimulatorConfig`

### Implementation Details
- Introduced a new type alias `PostSchedulingFn` for post-scheduling operations
- Added `post_scheduling_fn` field to `SimulatorConfig` to support custom interval adjustments
- Simplified interval calculation by removing the built-in fuzzing mechanism
- Updated test cases to reflect new behavior with modified expected values

### Breaking Changes
- Removed `fuzz_bounds`, `constrained_fuzz_bounds`, and related fuzzing functions
- Changed simulation result types from `Array1<T>` to `Vec<T>`
- Modified interval scheduling behavior which may affect simulation results