### PR TITLE
Feat/add card helper methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub use inference::{
 };
 pub use model::FSRS;
 pub use optimal_retention::{
-    extract_simulator_config, power_forgetting_curve, simulate, Card, PostSchedulingFn,
-    ReviewPriorityFn, RevlogEntry, RevlogReviewKind, SimulatorConfig,
+    extract_simulator_config, simulate, Card, PostSchedulingFn, ReviewPriorityFn, RevlogEntry,
+    RevlogReviewKind, SimulatorConfig,
 };
 pub use training::CombinedProgressState;

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -1339,9 +1339,6 @@ mod tests {
                 Ok(())
             };
 
-        let wrap = |f: Arc<
-            (dyn for<'a> Fn(&'a Card) -> i32 + std::marker::Send + std::marker::Sync + 'static),
-        >| Some(ReviewPriorityFn(f));
 
         macro_rules! wrap {
             ($f:expr) => {
@@ -1358,46 +1355,42 @@ mod tests {
         )?;
         println!("Low retrievability cards reviewed first.");
         run_test(
-            wrap(Arc::new(|card: &Card| {
-                (card.retrievability() * 1000.0) as i32
-            })),
+            wrap!(|card: &Card| {(card.retrievability() * 1000.0) as i32}),
             57.13894,
         )?;
         println!("High retrievability cards reviewed first.");
         run_test(
-            wrap(Arc::new(|card: &Card| {
-                -(card.retrievability() * 1000.0) as i32
-            })),
+            wrap!(|card: &Card| {-(card.retrievability() * 1000.0) as i32}),
             44.15335,
         )?;
         println!("High stability cards reviewed first.");
         run_test(
-            wrap(Arc::new(|card: &Card| -(card.stability * 100.0) as i32)),
+            wrap!(|card: &Card| -(card.stability * 100.0) as i32),
             45.77435,
         )?;
         println!("Low stability cards reviewed first.");
         run_test(
-            wrap(Arc::new(|card: &Card| (card.stability * 100.0) as i32)),
+            wrap!(|card: &Card| (card.stability * 100.0) as i32),
             48.288563,
         )?;
         println!("Long interval cards reviewed first.");
         run_test(
-            wrap(Arc::new(|card: &Card| -card.interval as i32)),
+            wrap!(|card: &Card| -card.interval as i32),
             46.02946,
         )?;
         println!("Short interval cards reviewed first.");
         run_test(
-            wrap(Arc::new(|card: &Card| card.interval as i32)),
+            wrap!(|card: &Card| card.interval as i32),
             45.916748,
         )?;
         println!("Early scheduled due cards reviewed first.");
         run_test(
-            wrap(Arc::new(|card: &Card| card.scheduled_due() as i32)),
+            wrap!(|card: &Card| card.scheduled_due() as i32),
             52.364307,
         )?;
         println!("Late scheduled due cards reviewed first.");
         run_test(
-            wrap(Arc::new(|card: &Card| -card.scheduled_due() as i32)),
+            wrap!(|card: &Card| -card.scheduled_due() as i32),
             43.113968,
         )?;
         Ok(())

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -1353,16 +1353,16 @@ mod tests {
         println!("Low retrievability cards reviewed first.");
         run_test(
             wrap(Box::new(|card: &Card| {
-                (card.retrievability() * 100.0) as i32
+                (card.retrievability() * 1000.0) as i32
             })),
-            56.962875,
+            57.13894,
         )?;
         println!("High retrievability cards reviewed first.");
         run_test(
             wrap(Box::new(|card: &Card| {
-                -(card.retrievability() * 100.0) as i32
+                -(card.retrievability() * 1000.0) as i32
             })),
-            44.702374,
+            44.15335,
         )?;
         println!("High stability cards reviewed first.");
         run_test(

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -1347,7 +1347,7 @@ mod tests {
         run_test(None, 43.632114)?;
         println!("High difficulty cards reviewed first.");
         run_test(
-            wrap(Box::new(|card: &Card| -(card.difficulty * 100.0) as i32)),
+            wrap(Arc::new(|card: &Card| -(card.difficulty * 100.0) as i32)),
             48.88666,
         )?;
         println!("Low retrievability cards reviewed first.");

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -1343,11 +1343,17 @@ mod tests {
             (dyn for<'a> Fn(&'a Card) -> i32 + std::marker::Send + std::marker::Sync + 'static),
         >| Some(ReviewPriorityFn(f));
 
+        macro_rules! wrap {
+            ($f:expr) => {
+                Some(ReviewPriorityFn(std::sync::Arc::new($f)))
+            };
+        }
+
         println!("Default behavior: low difficulty cards reviewed first.");
         run_test(None, 43.632114)?;
         println!("High difficulty cards reviewed first.");
         run_test(
-            wrap(Arc::new(|card: &Card| -(card.difficulty * 100.0) as i32)),
+            wrap!(|card: &Card| -(card.difficulty * 100.0) as i32),
             48.88666,
         )?;
         println!("Low retrievability cards reviewed first.");

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -1339,9 +1339,9 @@ mod tests {
                 Ok(())
             };
 
-        let wrap = |f: Box<
+        let wrap = |f: Arc<
             (dyn for<'a> Fn(&'a Card) -> i32 + std::marker::Send + std::marker::Sync + 'static),
-        >| Some(ReviewPriorityFn(Arc::new(f)));
+        >| Some(ReviewPriorityFn(f));
 
         println!("Default behavior: low difficulty cards reviewed first.");
         run_test(None, 43.632114)?;

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -1391,7 +1391,7 @@ mod tests {
         )?;
         println!("Late scheduled due cards reviewed first.");
         run_test(
-            wrap(Box::new(|card: &Card| -card.scheduled_due() as i32)),
+            wrap(Arc::new(|card: &Card| -card.scheduled_due() as i32)),
             43.113968,
         )?;
         Ok(())

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -1352,7 +1352,7 @@ mod tests {
         )?;
         println!("Low retrievability cards reviewed first.");
         run_test(
-            wrap(Box::new(|card: &Card| {
+            wrap(Arc::new(|card: &Card| {
                 (card.retrievability() * 1000.0) as i32
             })),
             57.13894,

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -1386,7 +1386,7 @@ mod tests {
         )?;
         println!("Early scheduled due cards reviewed first.");
         run_test(
-            wrap(Box::new(|card: &Card| card.scheduled_due() as i32)),
+            wrap(Arc::new(|card: &Card| card.scheduled_due() as i32)),
             52.364307,
         )?;
         println!("Late scheduled due cards reviewed first.");

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -1366,7 +1366,7 @@ mod tests {
         )?;
         println!("High stability cards reviewed first.");
         run_test(
-            wrap(Box::new(|card: &Card| -(card.stability * 100.0) as i32)),
+            wrap(Arc::new(|card: &Card| -(card.stability * 100.0) as i32)),
             45.77435,
         )?;
         println!("Low stability cards reviewed first.");

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -1371,7 +1371,7 @@ mod tests {
         )?;
         println!("Low stability cards reviewed first.");
         run_test(
-            wrap(Box::new(|card: &Card| (card.stability * 100.0) as i32)),
+            wrap(Arc::new(|card: &Card| (card.stability * 100.0) as i32)),
             48.288563,
         )?;
         println!("Long interval cards reviewed first.");

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -1339,7 +1339,6 @@ mod tests {
                 Ok(())
             };
 
-
         macro_rules! wrap {
             ($f:expr) => {
                 Some(ReviewPriorityFn(std::sync::Arc::new($f)))
@@ -1355,12 +1354,12 @@ mod tests {
         )?;
         println!("Low retrievability cards reviewed first.");
         run_test(
-            wrap!(|card: &Card| {(card.retrievability() * 1000.0) as i32}),
+            wrap!(|card: &Card| (card.retrievability() * 1000.0) as i32),
             57.13894,
         )?;
         println!("High retrievability cards reviewed first.");
         run_test(
-            wrap!(|card: &Card| {-(card.retrievability() * 1000.0) as i32}),
+            wrap!(|card: &Card| -(card.retrievability() * 1000.0) as i32),
             44.15335,
         )?;
         println!("High stability cards reviewed first.");
@@ -1374,25 +1373,13 @@ mod tests {
             48.288563,
         )?;
         println!("Long interval cards reviewed first.");
-        run_test(
-            wrap!(|card: &Card| -card.interval as i32),
-            46.02946,
-        )?;
+        run_test(wrap!(|card: &Card| -card.interval as i32), 46.02946)?;
         println!("Short interval cards reviewed first.");
-        run_test(
-            wrap!(|card: &Card| card.interval as i32),
-            45.916748,
-        )?;
+        run_test(wrap!(|card: &Card| card.interval as i32), 45.916748)?;
         println!("Early scheduled due cards reviewed first.");
-        run_test(
-            wrap!(|card: &Card| card.scheduled_due() as i32),
-            52.364307,
-        )?;
+        run_test(wrap!(|card: &Card| card.scheduled_due() as i32), 52.364307)?;
         println!("Late scheduled due cards reviewed first.");
-        run_test(
-            wrap!(|card: &Card| -card.scheduled_due() as i32),
-            43.113968,
-        )?;
+        run_test(wrap!(|card: &Card| -card.scheduled_due() as i32), 43.113968)?;
         Ok(())
     }
 
@@ -1408,9 +1395,9 @@ mod tests {
             learn_limit,
             ..Default::default()
         };
-        let optimal_retention = fsrs.optimal_retention(&config, &[], |_v| true).unwrap();
+        let optimal_retention = fsrs.optimal_retention(&config, &[], |_| true).unwrap();
         assert_eq!(optimal_retention, 0.82115597);
-        assert!(fsrs.optimal_retention(&config, &[1.], |_v| true).is_err());
+        assert!(fsrs.optimal_retention(&config, &[1.], |_| true).is_err());
         Ok(())
     }
 

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -1381,7 +1381,7 @@ mod tests {
         )?;
         println!("Short interval cards reviewed first.");
         run_test(
-            wrap(Box::new(|card: &Card| card.interval as i32)),
+            wrap(Arc::new(|card: &Card| card.interval as i32)),
             45.916748,
         )?;
         println!("Early scheduled due cards reviewed first.");

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -1376,7 +1376,7 @@ mod tests {
         )?;
         println!("Long interval cards reviewed first.");
         run_test(
-            wrap(Box::new(|card: &Card| -card.interval as i32)),
+            wrap(Arc::new(|card: &Card| -card.interval as i32)),
             46.02946,
         )?;
         println!("Short interval cards reviewed first.");

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -1359,7 +1359,7 @@ mod tests {
         )?;
         println!("High retrievability cards reviewed first.");
         run_test(
-            wrap(Box::new(|card: &Card| {
+            wrap(Arc::new(|card: &Card| {
                 -(card.retrievability() * 1000.0) as i32
             })),
             44.15335,


### PR DESCRIPTION
## Changes
- Added two helper methods to the `Card` struct:
  - `retrievability()`: Calculates the card's current retrievability based on its stability and time elapsed
  - `scheduled_due()`: Calculates when the card is scheduled to be due
- Refactored the review priority tests to:
  - Use the new helper methods where applicable
  - Introduce a `wrap` helper function to reduce code duplication
  - Add new test cases for scheduling based on due dates
- Removed unused `power_forgetting_curve` from public exports