### PR TITLE
Feat/Simulator Suspend After Lapse Count

### DIFF
--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -371,7 +371,7 @@ pub fn simulate(
             // Create 'forget' mask
             let forget = !rng.gen_bool(retrievability as f64);
 
-            card.lapses += if forget { 1 } else { 0 };
+            card.lapses += forget as u32;
 
             // Sample 'rating' for 'need_review' entries
             let rating = if forget {

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -304,7 +304,7 @@ pub fn simulate(
         let last_date_index = card.last_date as usize;
 
         // Guards
-        if card.due >= config.learn_span as f32 || card.lapses > max_lapses {
+        if card.due >= config.learn_span as f32 || card.lapses >= max_lapses {
             if !is_learn {
                 let delta_t = config.learn_span.max(last_date_index) - last_date_index;
                 let pre_sim_days = (-card.last_date) as usize;
@@ -1151,6 +1151,35 @@ mod tests {
         assert_eq!(memorized_cnt_per_day[0], 63.9);
         assert_eq!(review_cnt_per_day[0], 3);
         assert_eq!(learn_cnt_per_day[0], 60);
+        Ok(())
+    }
+
+    #[test]
+    fn simulate_suspend_on_lapse_count() -> Result<()> {
+        let cards = vec![Card {
+            difficulty: 10.0,
+            stability: f32::EPSILON,
+            last_date: -5.0,
+            due: 0.0,
+            interval: 5.0,
+            lapses: 0,
+        }];
+
+        let config = SimulatorConfig {
+            learn_limit: 1,
+            review_limit: 100,
+            learn_span: 200,
+            deck_size: cards.len(),
+            suspend_after_lapses: Some(1),
+            ..Default::default()
+        };
+
+        let SimulationResult {
+            review_cnt_per_day, ..
+        } = simulate(&config, &DEFAULT_PARAMETERS, 0.9, None, Some(cards))?;
+
+        assert_eq!(1, review_cnt_per_day.iter().sum::<usize>());
+
         Ok(())
     }
 


### PR DESCRIPTION
Tested with: https://github.com/Luc-Mcgrady/anki/tree/suspend-after-lapse-count

Limits for examples:
(1: no limit, 2: 14, 3: 7, 4: 100)
![image](https://github.com/user-attachments/assets/43e1d66a-d67c-4238-85e2-f44011e3d555)
![image](https://github.com/user-attachments/assets/833258aa-2ac3-4d67-bbae-1a22c5340590)
