### PR TITLE
Feat: Pass card instead of ivl to post scheduling function.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub use dataset::{FSRSItem, FSRSReview};
 pub use error::{FSRSError, Result};
 pub use inference::{
     DEFAULT_PARAMETERS, ItemProgress, ItemState, MemoryState, ModelEvaluation, NextStates,
+    next_interval,
 };
 pub use model::FSRS;
 pub use optimal_retention::{

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -429,7 +429,7 @@ pub fn simulate(
         card.due = day_index as f32 + ivl;
 
         if let Some(PostSchedulingFn(cb)) = &config.post_scheduling_fn {
-            ivl = cb(&card, config.max_ivl, day_index, &due_cnt_per_day, &mut rng);
+            ivl = cb(card, config.max_ivl, day_index, &due_cnt_per_day, &mut rng);
             card.interval = ivl;
             card.due = day_index as f32 + ivl;
         }


### PR DESCRIPTION
This future proofs the simulator in case any ideas like the deadline:
https://github.com/Luc-Mcgrady/anki/commit/fbff2f8318f5d995fc03b1a9cca5a18ab74c2d35
https://forums.ankiweb.net/t/deadline-exam-date-feature/56675/3?u=a_blokee
come to fruition.

Could be a better idea just to include stability as an argument? I just don't want 3.0.0 to release and be locked out of simulating this for the foreseeable future :laughing:.

Also exports `next_interval` from `inference`.