### PR TITLE
Feat/Card ids for simulation

### DIFF
--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -181,6 +181,9 @@ pub fn power_forgetting_curve(t: f32, s: f32) -> f32 {
 
 #[derive(Debug, Clone)]
 pub struct Card {
+    // "id" ignored by "simulate", used purely for hook functions (can be all be 0 with no consequence).
+    // new cards created by the simulation have negative id's so use positive ones.
+    pub id: i32,
     pub difficulty: f32,
     pub stability: f32,
     pub last_date: f32,
@@ -256,6 +259,7 @@ pub fn simulate(
 
     if config.learn_limit > 0 {
         let init_ratings = (0..(config.deck_size - cards.len())).map(|i| Card {
+            id: -(i as i32),
             difficulty: f32::NEG_INFINITY,
             stability: f32::NEG_INFINITY,
             last_date: f32::NEG_INFINITY,
@@ -1044,6 +1048,7 @@ mod tests {
         };
 
         let cards = vec![Card {
+            id: 0,
             difficulty: 5.0,
             stability: 5.0,
             last_date: -5.0,
@@ -1113,6 +1118,7 @@ mod tests {
         };
         let cards = vec![
             Card {
+                id: 0,
                 difficulty: 5.0,
                 stability: 5.0,
                 last_date: -5.0,
@@ -1121,6 +1127,7 @@ mod tests {
                 lapses: 0,
             },
             Card {
+                id: 0,
                 difficulty: 5.0,
                 stability: 2.0,
                 last_date: -2.0,
@@ -1129,6 +1136,7 @@ mod tests {
                 lapses: 0,
             },
             Card {
+                id: 0,
                 difficulty: 5.0,
                 stability: 2.0,
                 last_date: -2.0,
@@ -1137,6 +1145,7 @@ mod tests {
                 lapses: 0,
             },
             Card {
+                id: 0,
                 difficulty: 5.0,
                 stability: 2.0,
                 last_date: -8.0,
@@ -1160,6 +1169,7 @@ mod tests {
     #[test]
     fn simulate_suspend_on_lapse_count() -> Result<()> {
         let cards = vec![Card {
+            id: 0,
             difficulty: 10.0,
             stability: f32::EPSILON,
             last_date: -5.0,
@@ -1197,6 +1207,7 @@ mod tests {
 
         let cards = vec![
             Card {
+                id: 0,
                 difficulty: 5.0,
                 stability: 5.0,
                 last_date: -5.0,
@@ -1229,6 +1240,7 @@ mod tests {
 
         let cards = vec![
             Card {
+                id: 0,
                 difficulty: 5.0,
                 stability: 500.0,
                 last_date: -5.0,
@@ -1312,6 +1324,7 @@ mod tests {
         };
         let cards = vec![
             Card {
+                id: 0,
                 difficulty: 5.0,
                 stability: 5.0,
                 last_date: -5.0,
@@ -1320,6 +1333,7 @@ mod tests {
                 lapses: 0,
             },
             Card {
+                id: 0,
                 difficulty: 5.0,
                 stability: 2.0,
                 last_date: -2.0,


### PR DESCRIPTION
This could serve some niche uses with the hook functions. Does bloat the card struct a little though.
Example (suspend after rep count (just the reps that happen in the simulation, just an example)):
https://github.com/Luc-Mcgrady/anki/commit/d4440e6d4c3e9c6979f319e7eb080712c3aa026c
![image](https://github.com/user-attachments/assets/2081c34a-ae61-4de4-9283-f463856f1954)