### PR TITLE
Feat/historical memory states

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -113,7 +113,7 @@ impl<B: Backend> FSRS<B> {
 
     pub fn historical_memory_states(
         &self,
-        item: &FSRSItem,
+        item: FSRSItem,
         starting_state: Option<MemoryState>,
     ) -> Result<Vec<MemoryState>> {
         let (time_history, rating_history) = item_to_tensors(&item);


### PR DESCRIPTION
This PR adds a new method `historical_memory_states` to the FSRS implementation, which allows retrieving the memory states after each review in a card's history. It also refactors the tensor creation logic into a separate helper function `item_to_tensors` to reduce code duplication.

## Changes

1. Extracted tensor creation logic into a reusable helper function `item_to_tensors`
2. Added new `historical_memory_states` method to retrieve memory states after each review
3. Updated the `infer` method to use the new helper function

## Benefits

It's the prerequisite to reduce the Algorithm Complexity from O(n^2) to O(n) in card stats of Anki:

https://github.com/ankitects/anki/blob/9b5da546be49f37c8d6c286e09c86074b2f0c278/rslib/src/stats/card.rs#L145-L160