### PR TITLE
Add tests for memory state transitions in FSRS

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -622,6 +622,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "just for exploration"]
     fn short_term_vs_long_term() -> Result<()> {
         let fsrs = FSRS::new(Some(&DEFAULT_PARAMETERS))?;
         let state = MemoryState {
@@ -639,6 +640,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "just for exploration"]
     fn hard_vs_good_vs_easy() -> Result<()> {
         let fsrs = FSRS::new(Some(&DEFAULT_PARAMETERS))?;
         let item = FSRSItem {

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -622,6 +622,69 @@ mod tests {
     }
 
     #[test]
+    fn short_term_vs_long_term() -> Result<()> {
+        let fsrs = FSRS::new(Some(&DEFAULT_PARAMETERS))?;
+        let state = MemoryState {
+            stability: 10.0,
+            difficulty: 5.0,
+        };
+
+        let next_state = fsrs.next_states(Some(state), 0.9, 0)?.good.memory;
+        dbg!(next_state);
+        // let next_state = fsrs.next_states(Some(next_state), 0.9, 0)?.good.memory;
+        // dbg!(next_state);
+        let next_state = fsrs.next_states(Some(state), 0.9, 1)?.good.memory;
+        dbg!(next_state);
+        Ok(())
+    }
+
+    #[test]
+    fn hard_vs_good_vs_easy() -> Result<()> {
+        let fsrs = FSRS::new(Some(&DEFAULT_PARAMETERS))?;
+        let item = FSRSItem {
+            reviews: vec![
+                FSRSReview {
+                    rating: 2,
+                    delta_t: 0,
+                },
+                FSRSReview {
+                    rating: 3,
+                    delta_t: 0,
+                },
+                FSRSReview {
+                    rating: 3,
+                    delta_t: 0,
+                },
+            ],
+        };
+        let state = fsrs.memory_state(item, None).unwrap();
+        dbg!(state);
+        let item = FSRSItem {
+            reviews: vec![
+                FSRSReview {
+                    rating: 3,
+                    delta_t: 0,
+                },
+                FSRSReview {
+                    rating: 3,
+                    delta_t: 0,
+                },
+            ],
+        };
+        let state = fsrs.memory_state(item, None).unwrap();
+        dbg!(state);
+        let item = FSRSItem {
+            reviews: vec![FSRSReview {
+                rating: 4,
+                delta_t: 0,
+            }],
+        };
+        let state = fsrs.memory_state(item, None).unwrap();
+        dbg!(state);
+        Ok(())
+    }
+
+    #[test]
     fn current_retrievability() {
         let fsrs = FSRS::new(None).unwrap();
         let state = MemoryState {

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -623,7 +623,7 @@ mod tests {
 
     #[test]
     #[ignore = "just for exploration"]
-    fn short_term_vs_long_term() -> Result<()> {
+    fn stability_after_same_day_review_less_than_next_day_review() -> Result<()> {
         let fsrs = FSRS::new(Some(&DEFAULT_PARAMETERS))?;
         let state = MemoryState {
             stability: 10.0,
@@ -641,7 +641,7 @@ mod tests {
 
     #[test]
     #[ignore = "just for exploration"]
-    fn hard_vs_good_vs_easy() -> Result<()> {
+    fn init_stability_after_same_day_review_hard_vs_good_vs_easy() -> Result<()> {
         let fsrs = FSRS::new(Some(&DEFAULT_PARAMETERS))?;
         let item = FSRSItem {
             reviews: vec![


### PR DESCRIPTION
I'm adding more tests to detect problem of the short-term formula.

Related issue:
- https://github.com/open-spaced-repetition/fsrs4anki/issues/708 

## `short_term_vs_long_term`

Intuition: given the same rating, the SInc of the same-day review shouldn't be greater than the next-day review.

Current results:

```rs
[src/inference.rs:633:9] next_state = MemoryState {
    stability: 14.077712,
    difficulty: 4.9918327,
}
[src/inference.rs:637:9] next_state = MemoryState {
    stability: 12.528,
    difficulty: 4.9918327,
}
```

Potential solutions:
- https://github.com/open-spaced-repetition/fsrs-optimizer/pull/169
- maybe D decay?

## `hard_vs_good_vs_easy`

Due to learning step, the number of the necessary same-day reviews are different if the first rating is different.

Intuition: after the same-day reviews, S(hard) < S(good) < S(easy).

Current results:

```rs
[src/inference.rs:661:9] state = MemoryState {
    stability: 2.3461776,
    difficulty: 6.458347,
}
[src/inference.rs:675:9] state = MemoryState {
    stability: 4.4668584,
    difficulty: 5.272968,
}
[src/inference.rs:683:9] state = MemoryState {
    stability: 15.69105,
    difficulty: 3.2245016,
}
```