### PR TITLE
Fix/starting_state Not Included in historical_memory_states Output

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -123,6 +123,9 @@ impl<B: Backend> FSRS<B> {
     ) -> Result<Vec<MemoryState>> {
         let (time_history, rating_history) = self.item_to_tensors(&item);
         let mut states = vec![];
+        if let Some(starting_state) = starting_state {
+            states.push(starting_state);
+        }
         let [seq_len, _batch_size] = time_history.dims();
         let mut inner_state = starting_state.map(Into::into);
         for i in 0..seq_len {


### PR DESCRIPTION
Currently, in Anki, A card with a review history completely ignored by ignore_reviews_before except for 1 review  panics with
```
thread '<unnamed>' panicked at rslib/src/stats/card.rs:159:40:
attempt to subtract with overflow
```

I presume this is the fix for that? We could also fix it in Anki with:
```rs
            let mut memory_states =
                fsrs.historical_memory_states(item.item, item.starting_state)?;
            if let Some(starting_state) = item.starting_state {
                memory_states.insert(0, starting_state);
            }
```
I'm not sure if it's best to fix it like this or let the programmer decide if they want to insert the starting state themselves manually like above?