### PR TITLE
Fix/Missing-simulator-decay-for-fsrs5

### DIFF
--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -1,7 +1,7 @@
-use crate::{FSRS, FSRS5_DEFAULT_DECAY};
 use crate::error::{FSRSError, Result};
 use crate::inference::{ItemProgress, Parameters, S_MAX, S_MIN};
 use crate::model::check_and_fill_parameters;
+use crate::{FSRS, FSRS5_DEFAULT_DECAY};
 use burn::tensor::backend::Backend;
 use itertools::{Itertools, izip};
 use ndarray_rand::rand::distributions::WeightedIndex;

--- a/src/optimal_retention.rs
+++ b/src/optimal_retention.rs
@@ -1,4 +1,4 @@
-use crate::FSRS;
+use crate::{FSRS, FSRS5_DEFAULT_DECAY};
 use crate::error::{FSRSError, Result};
 use crate::inference::{ItemProgress, Parameters, S_MAX, S_MIN};
 use crate::model::check_and_fill_parameters;
@@ -232,13 +232,13 @@ fn mean_reversion(w: &[f32], init: f32, current: f32) -> f32 {
 }
 
 fn power_forgetting_curve(w: &[f32], t: f32, s: f32) -> f32 {
-    let decay = -w[20];
+    let decay = -w.get(20).unwrap_or(&FSRS5_DEFAULT_DECAY);
     let factor = 0.9f32.powf(1.0 / decay) - 1.0;
     (t / s).mul_add(factor, 1.0).powf(decay)
 }
 
 fn next_interval(w: &[f32], stability: f32, desired_retention: f32) -> f32 {
-    let decay = -w[20];
+    let decay = -w.get(20).unwrap_or(&FSRS5_DEFAULT_DECAY);
     let factor = 0.9f32.powf(1.0 / decay) - 1.0;
     stability / factor * (desired_retention.powf(1.0 / decay) - 1.0)
 }


### PR DESCRIPTION
:+1: 

related: https://forums.ankiweb.net/t/anki-25-05-beta-1/59710/15?u=a_blokee

Edit: How is this error even possible?

https://github.com/open-spaced-repetition/fsrs-rs/blob/3e2f0b423fed194d238cdcb55c1baccd0eca63f0/src/model.rs#L294-L298

Is a deeper fix than this needed?

Edit2: The bug is the weights for the priority functions don't have `check_and_fill_parameters` applied to them. I think this is the best fix after all.

https://github.com/ankitects/anki/blob/2406830ff949668403c60f52d56201f456e5a2d9/rslib/src/scheduler/fsrs/simulator.rs#L96-L101