### PR TITLE
add unit test of `memory state`

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -817,7 +817,7 @@ mod tests {
     }
     #[test]
     fn test_memory_state() {
-        let mut w = DEFAULT_PARAMETERS.clone();
+        let mut w = DEFAULT_PARAMETERS;
         assert_memory_state(&w, 49.4473, 6.8573);
         // freeze short term
         w[17] = 0.0;


### PR DESCRIPTION
I wish I had a baseline memory state to use as a reference... 👉👈

ref:
- https://github.com/open-spaced-repetition/py-fsrs/pull/104#discussion_r2096092411
- https://github.com/open-spaced-repetition/ts-fsrs/pull/187