### PR TITLE
Add Serialize trait to core data structures

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -1,5 +1,6 @@
 use burn::backend::ndarray::NdArrayDevice;
 use itertools::izip;
+use serde::Serialize;
 use std::collections::HashMap;
 use std::ops::{Add, Sub};
 
@@ -72,7 +73,7 @@ pub fn current_retrievability(state: MemoryState, days_elapsed: f32, decay: f32)
     (days_elapsed / state.stability * factor + 1.0).powf(-decay)
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, Serialize)]
 pub struct MemoryState {
     pub stability: f32,
     pub difficulty: f32,

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -612,7 +612,7 @@ pub struct ModelEvaluation {
     pub rmse_bins: f32,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct NextStates {
     pub again: ItemState,
     pub hard: ItemState,

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -620,7 +620,7 @@ pub struct NextStates {
     pub easy: ItemState,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize)]
 pub struct ItemState {
     pub memory: MemoryState,
     pub interval: f32,


### PR DESCRIPTION
This PR adds `Serialize` trait support to the core FSRS data structures, enabling serialization capabilities for key types
   used throughout the library.

ref :
- https://github.com/open-spaced-repetition/ts-fsrs/pull/223#discussion_r2393453866
- https://github.com/open-spaced-repetition/ts-fsrs/pull/223/commits/de2303dd5d9468047f014dd11e983621bd2d2ab1