### PR TITLE
Change default max_seq_len from 1024 to 256

### DIFF
--- a/src/training.rs
+++ b/src/training.rs
@@ -210,7 +210,7 @@ pub(crate) struct TrainingConfig {
     pub seed: u64,
     #[config(default = 4e-2)]
     pub learning_rate: f64,
-    #[config(default = 1024)]
+    #[config(default = 256)]
     pub max_seq_len: usize,
     #[config(default = 1.0)]
     pub gamma: f64,


### PR DESCRIPTION
On discord a user who has cards with extremely long histories is having trouble with slow optimization. I decided to lower the limit to 256. Note: ~2.7% of Anki users have cards with >256 reviews, and only ~0.02% of all cards are like that. In other words, most users don't have such cards at all, and even users who do have such cards only have a handful of them.