### PR TITLE
perf: speed up compute_parameters (windowed analytic gradient)

### DIFF
--- a/src/analytic.rs
+++ b/src/analytic.rs
@@ -715,6 +715,13 @@ fn card_column_loss_and_grad(
     };
     for t in 0..seq_len {
         let idx = t * batch + column;
+        // Trailing padding (rating 0) is a no-op passthrough: it scores nothing (weight 0) and
+        // carries a zero adjoint back through the state clamp, so it contributes neither loss nor
+        // gradient. A column's reviews are contiguous and then padded, so once the first padding
+        // step is hit the rest are all padding — stop at the card's real length. Bit-for-bit.
+        if r_hist[idx] == 0.0 {
+            break;
+        }
         let (next, cache) = step_forward(w, consts, state, t_hist[idx], r_hist[idx], t);
         let (step_loss, g_r) = if t == 0 {
             (0.0, 0.0)

--- a/src/analytic.rs
+++ b/src/analytic.rs
@@ -215,43 +215,58 @@ fn step_forward(
     let curve = curve_forward(w, delta_t, last_s, consts.factor);
     let r = curve.retrievability;
 
-    let hard_penalty = if rating == 2.0 { w[15] } else { 1.0 };
-    let easy_bonus = if rating == 4.0 { w[16] } else { 1.0 };
-    let success_inc = consts.exp_w8
-        * (11.0 - last_d)
-        * last_s.powf(-w[9])
-        * (((1.0 - r) * w[10]).exp() - 1.0)
-        * hard_penalty
-        * easy_bonus;
-    let success = last_s * (success_inc + 1.0);
-
-    let failure_raw = w[11]
-        * last_d.powf(-w[12])
-        * ((last_s + 1.0).powf(w[13]) - 1.0)
-        * ((1.0 - r) * w[14]).exp();
-    let failure_floor = last_s / consts.fail_floor_den;
-    let failure_used_floor = failure_floor < failure_raw;
-    let failure = if failure_used_floor {
-        failure_floor
-    } else {
-        failure_raw
-    };
-
-    let short_raw = (w[17] * (rating - 3.0 + w[18])).exp() * last_s.powf(-w[19]);
-    let short_raw_active = !(rating >= 2.0 && short_raw < 1.0);
-    let short_value = if rating >= 2.0 {
-        short_raw.max(1.0)
-    } else {
-        short_raw
-    };
-    let short = last_s * short_value;
-
     let use_short = delta_t == 0.0;
     let use_failure = rating == 1.0;
-    let mut new_s = if use_failure { failure } else { success };
-    if use_short {
-        new_s = short;
-    }
+    let padding = rating == 0.0;
+    let init_selected = nth == 0 && state.s == 0.0;
+
+    // Only the SELECTED stability branch is evaluated. The forward used to compute all three
+    // branches (success + failure + short = ~5 powf + 3 exp) every step and then pick one; since
+    // the selection and `step_backward` both dispatch on the same flags, computing the unused
+    // branches only wasted transcendentals. Padding / first-review init overwrite `new_s`
+    // entirely, so no branch is needed there at all. Cache fields for the inactive branches keep
+    // dummy values that `step_backward` never reads (it takes the same branch). Bit-for-bit.
+    let mut failure_raw = 0.0;
+    let mut failure_floor = 0.0;
+    let mut failure_used_floor = false;
+    let mut short_raw = 0.0;
+    let mut short_value = 0.0;
+    let mut short_raw_active = false;
+
+    let mut new_s = if padding || init_selected {
+        last_s // placeholder; overwritten by the init/padding blocks below
+    } else if use_short {
+        short_raw = (w[17] * (rating - 3.0 + w[18])).exp() * last_s.powf(-w[19]);
+        short_raw_active = !(rating >= 2.0 && short_raw < 1.0);
+        short_value = if rating >= 2.0 {
+            short_raw.max(1.0)
+        } else {
+            short_raw
+        };
+        last_s * short_value
+    } else if use_failure {
+        failure_raw = w[11]
+            * last_d.powf(-w[12])
+            * ((last_s + 1.0).powf(w[13]) - 1.0)
+            * ((1.0 - r) * w[14]).exp();
+        failure_floor = last_s / consts.fail_floor_den;
+        failure_used_floor = failure_floor < failure_raw;
+        if failure_used_floor {
+            failure_floor
+        } else {
+            failure_raw
+        }
+    } else {
+        let hard_penalty = if rating == 2.0 { w[15] } else { 1.0 };
+        let easy_bonus = if rating == 4.0 { w[16] } else { 1.0 };
+        let success_inc = consts.exp_w8
+            * (11.0 - last_d)
+            * last_s.powf(-w[9])
+            * (((1.0 - r) * w[10]).exp() - 1.0)
+            * hard_penalty
+            * easy_bonus;
+        last_s * (success_inc + 1.0)
+    };
 
     let delta_d = -w[6] * (rating - 3.0);
     let next_d = last_d + (10.0 - last_d) * delta_d / 9.0;
@@ -259,14 +274,12 @@ fn step_forward(
     let mean_d = w[7] * (easy_d - next_d) + next_d;
     let mut new_d = clamp(mean_d, D_MIN, D_MAX);
 
-    let init_selected = nth == 0 && state.s == 0.0;
     let init_rating = clamp(rating, 1.0, 4.0) as usize;
     if init_selected {
         new_s = w[init_rating - 1];
         new_d = clamp(init_difficulty(w, init_rating), D_MIN, D_MAX);
     }
 
-    let padding = rating == 0.0;
     if padding {
         new_s = last_s;
         new_d = last_d;

--- a/src/analytic.rs
+++ b/src/analytic.rs
@@ -43,6 +43,34 @@ struct State {
     d: f32,
 }
 
+/// Weight-only subexpressions of the forward step. They depend solely on the parameter vector
+/// `w`, so they are computed ONCE per loss/gradient call instead of once per (card × timestep).
+/// Identical f32 ops to the inline versions they replace, so this is bit-for-bit — it only lifts
+/// loop-invariant transcendentals out of the hot per-timestep recurrence (forward and the curve
+/// reconstruction in the backward).
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct FwdConsts {
+    /// `exp(ln(0.9) / decay) - 1`, with `decay = -w[20]`. Used by the forgetting curve.
+    factor: f32,
+    /// `exp(w[8])` — the success-stability prefactor.
+    exp_w8: f32,
+    /// `exp(w[17] * w[18])` — denominator of the lapse failure floor `s / exp(w17*w18)`.
+    fail_floor_den: f32,
+    /// `init_difficulty(w, 4)` — the easy-rating initial difficulty used by mean reversion.
+    easy_d: f32,
+}
+
+#[inline]
+fn fwd_consts(w: &[f32]) -> FwdConsts {
+    let decay = -w[20];
+    FwdConsts {
+        factor: ((0.9f32.ln()) / decay).exp() - 1.0,
+        exp_w8: w[8].exp(),
+        fail_floor_den: (w[17] * w[18]).exp(),
+        easy_d: init_difficulty(w, 4),
+    }
+}
+
 #[inline]
 fn clamp(x: f32, min: f32, max: f32) -> f32 {
     x.clamp(min, max)
@@ -93,10 +121,9 @@ fn bce_loss_and_grad_r(r_raw: f32, label: f32, weight: f32) -> (f64, f64) {
 /// `R(t, s) = (1 + max(t, 0) / s * factor)^decay`. The factor is chosen so that
 /// `R(s, s) = 0.9`, matching the FSRS definition of stability as the elapsed
 /// days at 90% retrievability.
-fn curve_forward(w: &[f32], t: f32, s: f32) -> CurveCache {
+fn curve_forward(w: &[f32], t: f32, s: f32, factor: f32) -> CurveCache {
     let t = t.max(0.0);
     let decay = -w[20];
-    let factor = ((0.9f32.ln()) / decay).exp() - 1.0;
     let base = t / s * factor + 1.0;
     let retrievability = base.powf(decay);
     CurveCache {
@@ -177,6 +204,7 @@ fn init_difficulty(w: &[f32], rating: usize) -> f32 {
 /// pre-clamp values so `step_backward` can use the same non-smooth path.
 fn step_forward(
     w: &[f32],
+    consts: FwdConsts,
     state: State,
     delta_t: f32,
     rating: f32,
@@ -184,12 +212,12 @@ fn step_forward(
 ) -> (State, StepCache) {
     let last_s = clamp(state.s, S_MIN, S_MAX);
     let last_d = clamp(state.d, D_MIN, D_MAX);
-    let curve = curve_forward(w, delta_t, last_s);
+    let curve = curve_forward(w, delta_t, last_s, consts.factor);
     let r = curve.retrievability;
 
     let hard_penalty = if rating == 2.0 { w[15] } else { 1.0 };
     let easy_bonus = if rating == 4.0 { w[16] } else { 1.0 };
-    let success_inc = w[8].exp()
+    let success_inc = consts.exp_w8
         * (11.0 - last_d)
         * last_s.powf(-w[9])
         * (((1.0 - r) * w[10]).exp() - 1.0)
@@ -201,7 +229,7 @@ fn step_forward(
         * last_d.powf(-w[12])
         * ((last_s + 1.0).powf(w[13]) - 1.0)
         * ((1.0 - r) * w[14]).exp();
-    let failure_floor = last_s / (w[17] * w[18]).exp();
+    let failure_floor = last_s / consts.fail_floor_den;
     let failure_used_floor = failure_floor < failure_raw;
     let failure = if failure_used_floor {
         failure_floor
@@ -227,7 +255,7 @@ fn step_forward(
 
     let delta_d = -w[6] * (rating - 3.0);
     let next_d = last_d + (10.0 - last_d) * delta_d / 9.0;
-    let easy_d = init_difficulty(w, 4);
+    let easy_d = consts.easy_d;
     let mean_d = w[7] * (easy_d - next_d) + next_d;
     let mut new_d = clamp(mean_d, D_MIN, D_MAX);
 
@@ -459,6 +487,7 @@ fn backward_init(w: &[f32], rating: usize, g_s: f64, g_d: f64, gw: &mut [f64]) {
 /// boundaries.
 fn step_backward(
     w: &[f32],
+    consts: FwdConsts,
     c: &StepCache,
     g_out_s: f64,
     g_out_d: f64,
@@ -497,8 +526,8 @@ fn step_backward(
         t: c.delta_t.max(0.0),
         s: c.last_s,
         decay: -w[20],
-        factor: ((0.9f32.ln()) / -w[20]).exp() - 1.0,
-        base: c.delta_t.max(0.0) / c.last_s * (((0.9f32.ln()) / -w[20]).exp() - 1.0) + 1.0,
+        factor: consts.factor,
+        base: c.delta_t.max(0.0) / c.last_s * consts.factor + 1.0,
         retrievability: c.retrievability,
     };
     g_last_s += curve_backward(w, curve, g_r, gw);
@@ -522,6 +551,7 @@ fn step_backward(
 /// walking the cached review steps in reverse.
 fn prefix_loss_and_grad(
     w: &[f32],
+    consts: FwdConsts,
     t_hist: &[f32],
     r_hist: &[f32],
     seq_len: usize,
@@ -541,19 +571,19 @@ fn prefix_loss_and_grad(
     };
     for t in 0..seq_len {
         let idx = t * batch + column;
-        let (next, cache) = step_forward(w, state, t_hist[idx], r_hist[idx], t);
+        let (next, cache) = step_forward(w, consts, state, t_hist[idx], r_hist[idx], t);
         state = next;
         if need_grad {
             caches.push(cache);
         }
     }
-    let curve = curve_forward(w, delta_t, state.s);
+    let curve = curve_forward(w, delta_t, state.s, consts.factor);
     let (loss, g_r) = bce_loss_and_grad_r(curve.retrievability, label, weight);
     if let Some(gw) = gw {
         let mut g_s = curve_backward(w, curve, g_r, gw);
         let mut g_d = 0.0;
         for cache in caches.iter().rev() {
-            let (prev_s, prev_d) = step_backward(w, cache, g_s, g_d, 0.0, gw);
+            let (prev_s, prev_d) = step_backward(w, consts, cache, g_s, g_d, 0.0, gw);
             g_s = prev_s;
             g_d = prev_d;
         }
@@ -579,10 +609,12 @@ pub(crate) fn batch_loss_and_grad(
     weights: &[f32],
     gw: &mut [f64],
 ) -> f64 {
+    let consts = fwd_consts(w);
     let mut loss = 0.0;
     for column in 0..batch {
         loss += prefix_loss_and_grad(
             w,
+            consts,
             t_hist,
             r_hist,
             seq_len,
@@ -613,10 +645,12 @@ pub(crate) fn batch_loss(
     labels: &[f32],
     weights: &[f32],
 ) -> f64 {
+    let consts = fwd_consts(w);
     let mut loss = 0.0;
     for column in 0..batch {
         loss += prefix_loss_and_grad(
             w,
+            consts,
             t_hist,
             r_hist,
             seq_len,
@@ -643,6 +677,7 @@ pub(crate) fn batch_loss(
 /// propagated backward through the entire cached card trajectory.
 fn card_column_loss_and_grad(
     w: &[f32],
+    consts: FwdConsts,
     t_hist: &[f32],
     r_hist: &[f32],
     seq_len: usize,
@@ -667,7 +702,7 @@ fn card_column_loss_and_grad(
     };
     for t in 0..seq_len {
         let idx = t * batch + column;
-        let (next, cache) = step_forward(w, state, t_hist[idx], r_hist[idx], t);
+        let (next, cache) = step_forward(w, consts, state, t_hist[idx], r_hist[idx], t);
         let (step_loss, g_r) = if t == 0 {
             (0.0, 0.0)
         } else {
@@ -684,7 +719,7 @@ fn card_column_loss_and_grad(
         let mut g_s = 0.0;
         let mut g_d = 0.0;
         for (t, cache) in caches.iter().enumerate().rev() {
-            let (prev_s, prev_d) = step_backward(w, cache, g_s, g_d, g_r_losses[t], gw);
+            let (prev_s, prev_d) = step_backward(w, consts, cache, g_s, g_d, g_r_losses[t], gw);
             g_s = prev_s;
             g_d = prev_d;
         }
@@ -709,10 +744,12 @@ pub(crate) fn card_loss_and_grad(
     weights: &[f32],
     gw: &mut [f64],
 ) -> f64 {
+    let consts = fwd_consts(w);
     let mut loss = 0.0;
     for column in 0..batch {
         loss += card_column_loss_and_grad(
             w,
+            consts,
             t_hist,
             r_hist,
             seq_len,
@@ -741,10 +778,11 @@ pub(crate) fn card_loss(
     labels: &[f32],
     weights: &[f32],
 ) -> f64 {
+    let consts = fwd_consts(w);
     let mut loss = 0.0;
     for column in 0..batch {
         loss += card_column_loss_and_grad(
-            w, t_hist, r_hist, seq_len, batch, column, labels, weights, None,
+            w, consts, t_hist, r_hist, seq_len, batch, column, labels, weights, None,
         );
     }
     loss

--- a/src/analytic.rs
+++ b/src/analytic.rs
@@ -125,7 +125,10 @@ fn curve_forward(w: &[f32], t: f32, s: f32, factor: f32) -> CurveCache {
     let t = t.max(0.0);
     let decay = -w[20];
     let base = t / s * factor + 1.0;
-    let retrievability = base.powf(decay);
+    // Same-day reviews (t == 0) have base == 1 exactly, so retrievability is 1 regardless of decay.
+    // Skip the wasted powf -- `1.powf(x)` is exactly 1, so this is bit-for-bit. Such steps are common
+    // (a card's first step and every same-day learning step).
+    let retrievability = if t == 0.0 { 1.0 } else { base.powf(decay) };
     CurveCache {
         t,
         s,


### PR DESCRIPTION
Written by Claude.

Three bit-for-bit optimizations to the card-grouped (`card_ids`) analytic
gradient path that dominates `compute_parameters`, building on the analytic
gradient from #411.

### Changes
1. **Hoist loop-invariant transcendentals** out of the per-step recurrence
   (curve factor `exp(ln0.9/decay)`, `exp(w8)`, `exp(w17*w18)`,
   `init_difficulty(w, 4)`) — computed once per call instead of once per
   (card x timestep).
2. **Evaluate only the active stability branch** in the forward step. It used
   to compute all three (success / lapse / same-day) and select one; since the
   selection and `step_backward` dispatch on the same flags, the unused
   branches were wasted transcendentals.
3. **Skip trailing-padding timesteps.** Cards are length-sorted and batched, so
   shorter cards carry trailing padding (rating 0) up to the batch-wide
   `seq_len`. That padding is a zero-gradient passthrough, yet the recurrence
   still evaluated a forgetting curve at each padding step — so stop each column
   at its real length.

### Correctness
All three are bit-for-bit: trained parameters and log loss are unchanged. The
`finite_difference_matches_batch_gradient`, `windowed_matches_sum_of_prefixes`,
and `test_analytic_loss_and_grad_matches_burn` tests pass (rebased on top of
\#416).

### Benchmark
`cargo bench --bench parameters` on a ~600k-review collection:
- `compute_parameters` (windowed): **about -22%**
- `compute_parameters_without_card_ids`: **about -30%**

### One more (~7%) I'd like your call on
The gradient path computes a BCE loss value that `train()` discards (only the
adjoint feeds the backward). Skipping it saves two `ln` per scored step
(about 7% on the bench here). But `test_analytic_loss_and_grad_matches_burn` and
`windowed_matches_sum_of_prefixes` assert that returned loss, so it can't be
dropped without either a `const SCORE_LOSS: bool` split (training skips the
loss; tests/validation keep it) or having those tests assert only the gradient.
Would you be open to either? Happy to send a follow-up.
