### PR TITLE
Add evaluate_with_card_ids: walk each card once instead of per item

### DIFF
--- a/benches/parameters.rs
+++ b/benches/parameters.rs
@@ -211,10 +211,6 @@ fn load_and_prepare_data_with_card_ids() -> (Vec<FSRSItem>, Vec<i64>) {
     [pretrain_set, train_set].concat().into_iter().unzip()
 }
 
-fn load_and_prepare_data() -> Vec<FSRSItem> {
-    load_and_prepare_data_with_card_ids().0
-}
-
 fn benchmark_evaluate(c: &mut Criterion) {
     let (items, card_ids) = load_and_prepare_data_with_card_ids();
     // Evaluate uses the FSRS instance's existing parameters.

--- a/benches/parameters.rs
+++ b/benches/parameters.rs
@@ -216,7 +216,7 @@ fn load_and_prepare_data() -> Vec<FSRSItem> {
 }
 
 fn benchmark_evaluate(c: &mut Criterion) {
-    let items = load_and_prepare_data();
+    let (items, card_ids) = load_and_prepare_data_with_card_ids();
     // Evaluate uses the FSRS instance's existing parameters.
     let fsrs = FSRS::default();
 
@@ -226,6 +226,17 @@ fn benchmark_evaluate(c: &mut Criterion) {
     group.bench_function("evaluate", |b| {
         b.iter(|| {
             fsrs.evaluate(black_box(items.clone()), |_| true).unwrap();
+        })
+    });
+
+    group.bench_function("evaluate_with_card_ids", |b| {
+        b.iter(|| {
+            fsrs.evaluate_with_card_ids(
+                black_box(items.clone()),
+                black_box(card_ids.clone()),
+                |_| true,
+            )
+            .unwrap();
         })
     });
 

--- a/src/convertor_tests.rs
+++ b/src/convertor_tests.rs
@@ -127,17 +127,28 @@ fn convert_to_fsrs_items(
 
 /// Convert a series of revlog entries sorted by card id into FSRS items.
 pub(crate) fn anki_to_fsrs(revlogs: Vec<RevlogEntry>) -> Vec<FSRSItem> {
+    anki_to_fsrs_with_card_ids(revlogs).0
+}
+
+/// Like [`anki_to_fsrs`], but also returns each item's originating card id (aligned with the
+/// items) — the `card_ids` convention used by `ComputeParametersInput` and
+/// `evaluate_with_card_ids`.
+pub(crate) fn anki_to_fsrs_with_card_ids(revlogs: Vec<RevlogEntry>) -> (Vec<FSRSItem>, Vec<i64>) {
     let mut revlogs = revlogs
         .into_iter()
         .chunk_by(|r| r.cid)
         .into_iter()
-        .filter_map(|(_cid, entries)| {
+        .filter_map(|(cid, entries)| {
             convert_to_fsrs_items(entries.collect(), 4, Tz::Asia__Shanghai)
+                .map(|items| items.into_iter().map(move |(id, item)| (id, cid, item)))
         })
         .flatten()
         .collect_vec();
-    revlogs.sort_by_cached_key(|(id, _)| *id);
-    revlogs.into_iter().map(|(_, item)| item).collect()
+    revlogs.sort_by_cached_key(|(id, _, _)| *id);
+    revlogs
+        .into_iter()
+        .map(|(_, cid, item)| (item, cid))
+        .unzip()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -182,6 +193,10 @@ pub(crate) fn data_from_csv() -> Vec<FSRSItem> {
 
 pub(crate) fn anki21_sample_file_converted_to_fsrs() -> Vec<FSRSItem> {
     anki_to_fsrs(read_collection().expect("read error"))
+}
+
+pub(crate) fn anki21_sample_file_converted_to_fsrs_with_card_ids() -> (Vec<FSRSItem>, Vec<i64>) {
+    anki_to_fsrs_with_card_ids(read_collection().expect("read error"))
 }
 
 pub(crate) fn read_collection() -> Result<Vec<RevlogEntry>> {

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -1107,7 +1107,6 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn test_evaluate_with_card_ids_matches_evaluate() -> Result<()> {
         let (items, card_ids) = anki21_sample_file_converted_to_fsrs_with_card_ids();
         for fsrs in [FSRS::default(), FSRS::new(PARAMETERS)?] {

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -4,7 +4,10 @@ use std::collections::HashMap;
 use std::ops::{Add, Sub};
 use std::sync::{Arc, Mutex};
 
-use crate::dataset::{constant_weighted_fsrs_items, recency_weighted_fsrs_items};
+use crate::dataset::{
+    WeightedFSRSItem, constant_weighted_fsrs_items, recency_weighted_fsrs_items,
+    recency_weighted_fsrs_items_with_card_ids,
+};
 use crate::error::Result;
 use crate::model::FSRS;
 use crate::simulation::{D_MAX, D_MIN, S_MIN};
@@ -430,6 +433,141 @@ impl FSRS {
         })
     }
 
+    /// Like [`Self::evaluate`], but additionally takes `card_ids` aligned with `items` (the same
+    /// convention as [`ComputeParametersInput::card_ids`]): items from the same card are
+    /// expanding-window prefixes of one review history, so each card's memory-state trajectory
+    /// is computed ONCE and every item's retrievability is read off along the way. This turns
+    /// the model work from O(sum of prefix lengths) into O(total reviews), while producing the
+    /// exact same per-item predictions and log loss as [`Self::evaluate`] (identical arithmetic
+    /// in identical accumulation order; RMSE matches up to the last float bits, since its bin
+    /// map is summed in `HashMap` iteration order, which differs between any two calls). A card
+    /// whose items do not form a prefix chain falls back to the per-item path, so the result is
+    /// equivalent for arbitrary inputs.
+    ///
+    /// Callers that already build `card_ids` for [`crate::compute_parameters`] can pass the
+    /// same vector here (e.g. Anki, which evaluates both the current and the optimized
+    /// parameters right after optimizing).
+    pub fn evaluate_with_card_ids<F>(
+        &self,
+        items: Vec<FSRSItem>,
+        card_ids: Vec<i64>,
+        mut progress: F,
+    ) -> Result<ModelEvaluation>
+    where
+        F: FnMut(ItemProgress) -> bool,
+    {
+        if items.is_empty() {
+            return Err(FSRSError::NotEnoughData);
+        }
+        if card_ids.len() != items.len() {
+            return Err(FSRSError::InvalidInput);
+        }
+        let weighted_items = recency_weighted_fsrs_items_with_card_ids(items, card_ids);
+
+        // Group item indices by card id, in first-appearance order.
+        let mut group_index: HashMap<i64, usize> = HashMap::new();
+        let mut groups: Vec<Vec<usize>> = Vec::new();
+        for (idx, weighted_item) in weighted_items.iter().enumerate() {
+            let group = *group_index.entry(weighted_item.card_id).or_insert_with(|| {
+                groups.push(Vec::new());
+                groups.len() - 1
+            });
+            groups[group].push(idx);
+        }
+
+        let mut predictions = vec![0.0f32; weighted_items.len()];
+        let mut progress_info = ItemProgress {
+            current: 0,
+            total: weighted_items.len(),
+        };
+        for group in &groups {
+            self.predict_card_group(&weighted_items, group, &mut predictions)?;
+            progress_info.current += group.len();
+            if !progress(progress_info) {
+                return Err(FSRSError::Interrupted);
+            }
+        }
+
+        // Aggregate in the original item order — the same arithmetic in the same accumulation
+        // order as `evaluate`, so the resulting metrics are bit-for-bit identical.
+        let mut r_matrix: HashMap<(u32, u32, u32), RMatrixValue> = HashMap::new();
+        let mut preds = Vec::with_capacity(weighted_items.len());
+        let mut labels = Vec::with_capacity(weighted_items.len());
+        let mut weights = Vec::with_capacity(weighted_items.len());
+        for (idx, weighted_item) in weighted_items.iter().enumerate() {
+            let p = predictions[idx];
+            let y = f32::from(weighted_item.item.current().rating > 1);
+            let bin = weighted_item.item.r_matrix_index();
+            let value = r_matrix.entry(bin).or_default();
+            value.predicted += p;
+            value.actual += y;
+            value.count += 1.0;
+            value.weight += weighted_item.weight;
+            preds.push(p);
+            labels.push(y);
+            weights.push(weighted_item.weight);
+        }
+        let rmse = rmse_bins(&r_matrix);
+        let loss = weighted_binary_cross_entropy(&preds, &labels, &weights);
+        if !loss.is_finite() || !rmse.is_finite() {
+            return Err(FSRSError::InvalidInput);
+        }
+        Ok(ModelEvaluation {
+            log_loss: loss,
+            rmse_bins: rmse,
+        })
+    }
+
+    /// Fill `predictions` for one card's items. If the items form an expanding-window prefix
+    /// chain (every shorter history is a prefix of the longest one), the card's state
+    /// trajectory is walked once using the exact per-review steps `forward_reviews` would
+    /// take; otherwise every item falls back to [`predict_retrievability`].
+    fn predict_card_group(
+        &self,
+        weighted_items: &[WeightedFSRSItem],
+        group: &[usize],
+        predictions: &mut [f32],
+    ) -> Result<()> {
+        let mut order = group.to_vec();
+        order.sort_by_key(|&idx| weighted_items[idx].item.reviews.len());
+        let longest = &weighted_items[*order.last().unwrap()].item.reviews;
+        let chain = order.iter().all(|&idx| {
+            let reviews = &weighted_items[idx].item.reviews;
+            longest[..reviews.len()] == reviews[..]
+        });
+        if !chain {
+            for &idx in group {
+                predictions[idx] = predict_retrievability(self, &weighted_items[idx].item)?;
+            }
+            return Ok(());
+        }
+        let mut state: Option<MemoryState> = None;
+        let mut applied = 0;
+        for &idx in &order {
+            let reviews = &weighted_items[idx].item.reviews;
+            if reviews.is_empty() {
+                return Err(FSRSError::InvalidInput);
+            }
+            let history_len = reviews.len() - 1;
+            while applied < history_len {
+                let review = &longest[applied];
+                state = Some(match state {
+                    None => self.init_state_from_first_review(review),
+                    Some(state) => self.step(review.delta_t as f32, review.rating, state, applied),
+                });
+                applied += 1;
+            }
+            let stability = state.as_ref().map_or(0.0, |state| state.stability);
+            let retrievability =
+                self.power_forgetting_curve(reviews[history_len].delta_t as f32, stability);
+            if !retrievability.is_finite() {
+                return Err(FSRSError::InvalidInput);
+            }
+            predictions[idx] = retrievability;
+        }
+        Ok(())
+    }
+
     /// Returns the universal metrics for the existing and provided parameters. If the first value
     /// is smaller than the second value, the existing parameters are better than the provided ones.
     pub fn universal_metrics<F>(
@@ -749,8 +887,14 @@ fn measure_a_by_b(pred_a: &[f32], pred_b: &[f32], true_val: &[f32]) -> f32 {
 mod tests {
     use super::*;
     use crate::{
-        FSRSReview, convertor_tests::anki21_sample_file_converted_to_fsrs, current_retrievability,
-        dataset::filter_outlier, test_helpers::TestHelper,
+        FSRSReview,
+        convertor_tests::{
+            anki21_sample_file_converted_to_fsrs,
+            anki21_sample_file_converted_to_fsrs_with_card_ids,
+        },
+        current_retrievability,
+        dataset::filter_outlier,
+        test_helpers::TestHelper,
     };
 
     static PARAMETERS: &[f32] = &[
@@ -959,6 +1103,39 @@ mod tests {
 
         [self_by_other, other_by_self].assert_approx_eq([0.014087644, 0.017199915]);
 
+        Ok(())
+    }
+
+    #[test]
+    #[test]
+    fn test_evaluate_with_card_ids_matches_evaluate() -> Result<()> {
+        let (items, card_ids) = anki21_sample_file_converted_to_fsrs_with_card_ids();
+        for fsrs in [FSRS::default(), FSRS::new(PARAMETERS)?] {
+            let plain = fsrs.evaluate(items.clone(), |_| true)?;
+            let windowed =
+                fsrs.evaluate_with_card_ids(items.clone(), card_ids.clone(), |_| true)?;
+            // Same per-item arithmetic in the same accumulation order -> bit-for-bit equal.
+            // Per-item predictions and their accumulation order are identical, so log loss is
+            // bit-for-bit equal. RMSE(bins) sums over `HashMap::values()`, whose iteration order
+            // differs between map instances — so it can differ in the last float bits between
+            // ANY two evaluate calls; compare it with a tight tolerance instead.
+            assert_eq!(plain.log_loss, windowed.log_loss);
+            assert!((plain.rmse_bins - windowed.rmse_bins).abs() < 1e-6);
+
+            // Groupings that are NOT expanding-window prefix chains fall back to the per-item
+            // path and must stay identical too.
+            let bogus_ids: Vec<i64> = (0..items.len() as i64).map(|i| i % 7).collect();
+            let fallback = fsrs.evaluate_with_card_ids(items.clone(), bogus_ids, |_| true)?;
+            assert_eq!(plain.log_loss, fallback.log_loss);
+            assert!((plain.rmse_bins - fallback.rmse_bins).abs() < 1e-6);
+        }
+
+        // card_ids must be aligned with items.
+        assert!(
+            FSRS::default()
+                .evaluate_with_card_ids(items, vec![0], |_| true)
+                .is_err()
+        );
         Ok(())
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -167,6 +167,25 @@ impl FSRS {
         step(&self.parameters, delta_t, rating as f32, state, nth)
     }
 
+    /// Memory state right after a card's FIRST review — the initialization branch of
+    /// [`Self::forward_reviews`]. Factored out so the card-walk evaluation path
+    /// ([`Self::evaluate_with_card_ids`]) uses the exact same initialization and the two can
+    /// never drift apart.
+    pub(crate) fn init_state_from_first_review(&self, review: &FSRSReview) -> MemoryState {
+        if review.rating == 0 {
+            MemoryState {
+                stability: S_MIN,
+                difficulty: D_MIN,
+            }
+        } else {
+            let rating = review.rating.clamp(1, 4);
+            MemoryState {
+                stability: self.init_stability(rating).clamp(S_MIN, S_MAX),
+                difficulty: self.init_difficulty(rating).clamp(D_MIN, D_MAX),
+            }
+        }
+    }
+
     /// If [starting_state] is provided, it will be used instead of the default initial stability/
     /// difficulty.
     pub(crate) fn forward_reviews(
@@ -185,25 +204,7 @@ impl FSRS {
                 0,
             )
         } else {
-            let rating = reviews[0].rating;
-            if rating == 0 {
-                (
-                    MemoryState {
-                        stability: S_MIN,
-                        difficulty: D_MIN,
-                    },
-                    1,
-                )
-            } else {
-                let rating = rating.clamp(1, 4);
-                (
-                    MemoryState {
-                        stability: self.init_stability(rating).clamp(S_MIN, S_MAX),
-                        difficulty: self.init_difficulty(rating).clamp(D_MIN, D_MAX),
-                    },
-                    1,
-                )
-            }
+            (self.init_state_from_first_review(&reviews[0]), 1)
         };
 
         for (index, review) in reviews.iter().enumerate().skip(start_index) {


### PR DESCRIPTION
Written by Claude

## Summary

`evaluate()` re-runs the full review history for every expanding-window item, so its model work is O(sum of prefix lengths). This PR adds `evaluate_with_card_ids(items, card_ids, progress)`: when the caller supplies `card_ids` (the same aligned vector `ComputeParametersInput` already takes), items from one card are prefixes of a single history, so each card's memory-state trajectory is walked **once** and every item's retrievability is read off along the way — O(total reviews) model work.

- `forward_reviews`' first-review initialization is factored into `init_state_from_first_review`, and the card walk uses the exact same per-review `step` calls, so the two paths cannot drift.
- Per-item predictions and **log loss are bit-for-bit identical** to `evaluate()` (same arithmetic in the same accumulation order). RMSE matches up to the last float bits — its bin map is summed in `HashMap` iteration order, which already differs between any two `evaluate()` calls.
- A card whose items do **not** form an expanding-window prefix chain falls back to the per-item path, so results are equivalent for arbitrary inputs (covered by a test with deliberately wrong groupings).
- `evaluate()` itself is unchanged.

## Motivation

After #411/#419/#424 sped `compute_parameters` up ~20x, the plain `evaluate()` became the dominant cost in Anki's optimize flow, which calls it twice (current + optimized parameters) right after training — measured at up to ~2x the cost of the training itself for large collections. Anki already builds the aligned `card_ids` vector for training and can pass the same vector here (happy to file that follow-up PR against Anki once this lands).

## Performance

`cargo bench --bench parameters -- evaluate` (anki21 sample):

| bench | time |
|---|---|
| `evaluate` | 1.033 s |
| `evaluate_with_card_ids` | 311.8 ms (~3.3x faster) |

The remaining windowed cost is mostly the per-item `r_matrix_index()` integer walks, not the model forward.

## Testing

- `test_evaluate_with_card_ids_matches_evaluate`: on the anki21 sample (441k items), asserts log loss is bit-for-bit equal to `evaluate()` (for both default and custom parameters), that non-prefix-chain groupings (fallback path) stay identical, and that misaligned `card_ids` error.
- `cargo test --release`, `cargo clippy --all-targets --release`, `cargo fmt` — clean (pre-existing test-data failures on this Windows machine aside, which also occur on unmodified `main`).
